### PR TITLE
docs: add missing /mgw:init command to README

### DIFF
--- a/.claude/commands/mgw/run.md
+++ b/.claude/commands/mgw/run.md
@@ -26,6 +26,20 @@ For new-milestone: runs full milestone flow, posting updates after each phase.
 The orchestrator stays thin — all heavy work (analysis, GSD execution, GitHub
 operations) happens in task agents with fresh context.
 
+HARD CONSTRAINTS — the orchestrator MUST NOT violate these:
+- NEVER edit, write, or modify source/implementation files directly. All code
+  changes go through gsd-executor Task agents. The orchestrator only writes to
+  .mgw/ state files and .planning/ artifacts.
+- NEVER use `git checkout -b` or `git switch -c`. All work happens in isolated
+  worktrees created with `git worktree add`.
+- NEVER skip the gsd-planner Task agent. Even for "simple" or "obvious" changes,
+  the planner creates the plan. The orchestrator does not plan implementation.
+- NEVER skip the gsd-executor Task agent. Even for 1-file changes, the executor
+  implements and commits. The orchestrator does not implement.
+- The orchestrator's ONLY direct actions are: state management (.mgw/), directory
+  creation (.planning/), spawning Task agents, running gsd-tools.cjs, and git
+  worktree operations.
+
 Checkpoints requiring user input:
 - Triage confirmation (if not already triaged)
 - GSD route confirmation
@@ -146,6 +160,11 @@ Log comment in state file (at `${REPO_ROOT}/.mgw/active/`).
 **Execute GSD pipeline (quick / quick --full route):**
 
 Only run this step if gsd_route is "gsd:quick" or "gsd:quick --full".
+
+⚠ REMINDER: You are the orchestrator. Do NOT read source files to "understand
+the codebase" and then edit them yourself. Spawn the gsd-planner and gsd-executor
+Task agents below — they do all the implementation work. Your job here is only to
+run gsd-tools.cjs init, create directories, spawn agents, and update state.
 
 Update pipeline_stage to "executing" in state file (at `${REPO_ROOT}/.mgw/active/`).
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ So I built MGW to be the responsible adult in the room. I point it at an issue, 
 
 | Command | What it does |
 |---------|-------------|
+| `/mgw:init` | Bootstrap repo for MGW — state directory, GitHub templates, labels |
 | `/mgw:issues` | Browse and filter your GitHub issues |
 | `/mgw:issue <n>` | Deep triage — scope analysis, security review, GSD route recommendation |
 | `/mgw:run <n>` | Full autonomous pipeline: triage through PR creation |
@@ -127,7 +128,7 @@ stow -v -R -t ~ mgw
 
 ```bash
 ls ~/.claude/commands/mgw/
-# help.md  issue.md  issues.md  link.md  pr.md  run.md  sync.md  update.md  workflows/
+# help.md  init.md  issue.md  issues.md  link.md  pr.md  run.md  sync.md  update.md  workflows/
 ```
 
 Then in Claude Code:
@@ -139,6 +140,9 @@ Then in Claude Code:
 ## Typical Workflow
 
 ```bash
+# 0. First time? Bootstrap your repo
+/mgw:init
+
 # 1. See what's assigned to you
 /mgw:issues
 
@@ -170,6 +174,7 @@ Or go manual for more control:
   commands/
     mgw/
       help.md              Command reference display
+      init.md              Repo bootstrap — state, templates, labels
       issues.md            Issue browser with filters
       issue.md             Deep triage with agent analysis
       update.md            Structured GitHub comments


### PR DESCRIPTION
## Summary
- Added `/mgw:init` to the Commands table, project structure listing, verify output, and typical workflow section — the command was added in cd1cc6c but the README was never updated
- Added hard constraints to `run.md` preventing the orchestrator from directly editing source files or bypassing planner/executor agents

## Changes
- **README.md** — 4 doc-audit fixes: commands table row, `ls` verify output, typical workflow step 0, project structure tree entry
- **.claude/commands/mgw/run.md** — Added `HARD CONSTRAINTS` block and mid-process reminder enforcing orchestrator-only responsibilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)