### PR TITLE
feat: integrate gsd-tools commands and enrich context passing

### DIFF
--- a/.claude/commands/mgw/issue.md
+++ b/.claude/commands/mgw/issue.md
@@ -84,6 +84,11 @@ Report: "Assigned #$ISSUE_NUMBER to $GH_USER"
 <step name="spawn_analysis">
 **Spawn task agent for codebase analysis:**
 
+Gather GSD project history for context (if available):
+```bash
+HISTORY=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs history-digest 2>/dev/null || echo "")
+```
+
 Build analysis prompt from issue data and spawn:
 
 ```
@@ -97,6 +102,10 @@ Body: ${body}
 Labels: ${labels}
 Comments: ${comments_summary}
 </issue>
+
+<project_history>
+${HISTORY}
+</project_history>
 
 <analysis_dimensions>
 
@@ -196,7 +205,11 @@ AskUserQuestion(
 
 If accepted or overridden (not rejected):
 
-Generate slug from title (lowercase, hyphens, 40 char max).
+Generate slug from title using gsd-tools:
+```bash
+SLUG=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs generate-slug "${issue_title}" --raw)
+SLUG="${SLUG:0:40}"  # gsd-tools doesn't truncate; MGW enforces 40-char limit
+```
 Write to `.mgw/active/${ISSUE_NUMBER}-${slug}.json` using the schema from state.md.
 
 Populate:

--- a/.claude/commands/mgw/link.md
+++ b/.claude/commands/mgw/link.md
@@ -72,7 +72,7 @@ Check for duplicate (same a+b pair exists). If duplicate, report and skip.
 
 Append new link:
 ```json
-{ "a": "${ref_a}", "b": "${ref_b}", "type": "${link_type}", "created": "${ISO_TIMESTAMP}" }
+{ "a": "${ref_a}", "b": "${ref_b}", "type": "${link_type}", "created": "$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs current-timestamp --raw)" }
 ```
 
 Write back to `.mgw/cross-refs.json`.

--- a/.claude/commands/mgw/pr.md
+++ b/.claude/commands/mgw/pr.md
@@ -52,21 +52,26 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 
 **Linked mode:** Read state file for gsd_artifacts.path, then:
 ```bash
-# Find SUMMARY and VERIFICATION files
-find ${gsd_artifacts_path} -name "*SUMMARY*" -o -name "*VERIFICATION*" 2>/dev/null
+# Structured summary data via gsd-tools (returns JSON with one_liner, key_files, tech_added, patterns, decisions)
+SUMMARY_DATA=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs summary-extract "${gsd_artifacts_path}/*SUMMARY*" 2>/dev/null || echo '{}')
+# Also read raw artifacts for full context
+SUMMARY_RAW=$(cat ${gsd_artifacts_path}/*SUMMARY* 2>/dev/null)
+VERIFICATION=$(cat ${gsd_artifacts_path}/*VERIFICATION* 2>/dev/null)
+# Progress table for details section
+PROGRESS_TABLE=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs progress table --raw 2>/dev/null || echo "")
 ```
 
 **Standalone mode:** Search .planning/ for recent artifacts:
 ```bash
-# Check quick tasks
-ls -t .planning/quick/*/SUMMARY.md 2>/dev/null | head -1
-# Check phase artifacts
-ls -t .planning/phases/*/SUMMARY.md 2>/dev/null | head -1
+# Check quick tasks first, then phases
+SUMMARY_PATH=$(ls -t .planning/quick/*/SUMMARY.md .planning/phases/*/SUMMARY.md 2>/dev/null | head -1)
+if [ -n "$SUMMARY_PATH" ]; then
+  SUMMARY_DATA=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs summary-extract "$SUMMARY_PATH" 2>/dev/null || echo '{}')
+  SUMMARY_RAW=$(cat "$SUMMARY_PATH" 2>/dev/null)
+fi
 ```
 
 If no GSD artifacts found → fall back to `git log ${base}..HEAD --oneline` for PR content.
-
-Read found artifacts and extract key content.
 </step>
 
 <step name="build_pr_body">
@@ -84,12 +89,16 @@ ${issue_title_and_body_if_linked}
 Issue: #${ISSUE_NUMBER} (or 'none — standalone')
 </issue_context>
 
-<gsd_summary>
-${SUMMARY_MD_CONTENT}
-</gsd_summary>
+<gsd_summary_structured>
+${SUMMARY_DATA}
+</gsd_summary_structured>
+
+<gsd_summary_raw>
+${SUMMARY_RAW}
+</gsd_summary_raw>
 
 <gsd_verification>
-${VERIFICATION_MD_CONTENT_IF_EXISTS}
+${VERIFICATION}
 </gsd_verification>
 
 <cross_refs>
@@ -106,14 +115,25 @@ Return EXACTLY two sections separated by ===TESTING===:
 SECTION 1 — PR body:
 ## Summary
 - [2-4 bullet points of what changed and why]
+- [Use one_liner from gsd_summary_structured if available]
 
 ${if_linked: 'Closes #${ISSUE_NUMBER}'}
 
 ## Changes
 - [File-level changes grouped by system/module]
+- [Use key_files from gsd_summary_structured if available]
 
 ## Cross-References
 ${cross_ref_list_or_omit_if_none}
+
+${if PROGRESS_TABLE non-empty:
+<details>
+<summary>GSD Progress</summary>
+
+${PROGRESS_TABLE}
+
+</details>
+}
 
 ===TESTING===
 

--- a/.claude/commands/mgw/run.md
+++ b/.claude/commands/mgw/run.md
@@ -124,12 +124,20 @@ Add cross-ref (at `${REPO_ROOT}/.mgw/cross-refs.json`): issue → branch.
 <step name="post_start_update">
 **Post "work started" comment (task agent):**
 
+Gather enrichment data from triage state and GSD progress:
+```bash
+SCOPE_SUMMARY="${triage.scope.files} files across ${triage.scope.systems}"
+PROGRESS=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs progress bar --raw 2>/dev/null || echo "")
+```
+
 ```
 Task(
   prompt="Post a GitHub issue comment.
 Issue: ${ISSUE_NUMBER}
 Comment body:
 **Work Started** — Triaged as \`${gsd_route}\`. Execution beginning on branch \`${BRANCH_NAME}\`.
+Scope: ${SCOPE_SUMMARY}
+${PROGRESS ? 'Progress: ' + PROGRESS : ''}
 
 Command: gh issue comment ${ISSUE_NUMBER} --body '<comment_body>'
 ",
@@ -153,15 +161,29 @@ Determine flags:
 - "gsd:quick" → $QUICK_FLAGS = ""
 - "gsd:quick --full" → $QUICK_FLAGS = "--full"
 
-Read the issue description to use as the GSD task description:
+Read the issue description to use as the GSD task description (full body, capped at 5000 chars for pathological issues):
 ```
-$TASK_DESCRIPTION = "Issue #${ISSUE_NUMBER}: ${issue_title}\n\n${issue_body_truncated_to_500_chars}"
+$TASK_DESCRIPTION = "Issue #${ISSUE_NUMBER}: ${issue_title}\n\n${issue_body}"  # full body, max 5000 chars
 ```
 
 Execute the GSD quick workflow. Read and follow the quick workflow steps:
 
 1. **Init:** `node ~/.claude/get-shit-done/bin/gsd-tools.cjs init quick "$DESCRIPTION"`
    Parse JSON for: planner_model, executor_model, checker_model, verifier_model, next_num, slug, date, quick_dir, task_dir.
+
+   **Handle missing ROADMAP.md:** Check `roadmap_exists` from init output. If false, create minimal GSD scaffolding so quick workflow has valid state:
+   ```bash
+   if [ "$roadmap_exists" = "false" ]; then
+     mkdir -p .planning/quick
+     echo '{"model_profile":"balanced","commit_docs":true}' > .planning/config.json
+     cat > .planning/ROADMAP.md << 'HEREDOC'
+   # Roadmap
+   ## v1.0: MGW-Managed
+   Issue-driven development managed by MGW.
+   HEREDOC
+   fi
+   ```
+   This creates valid GSD state that survives if someone later uses native GSD commands.
 
 2. **Create task directory:**
 ```bash
@@ -178,6 +200,18 @@ Task(
 **Mode:** ${FULL_MODE ? 'quick-full' : 'quick'}
 **Directory:** ${QUICK_DIR}
 **Description:** ${TASK_DESCRIPTION}
+
+<triage_context>
+Scope: ${triage.scope.files} files across systems: ${triage.scope.systems}
+Validity: ${triage.validity}
+Security: ${triage.security_notes}
+Conflicts: ${triage.conflicts}
+GSD Route: ${gsd_route}
+</triage_context>
+
+<issue_comments>
+${recent_comments}
+</issue_comments>
 
 <files_to_read>
 - .planning/STATE.md (Project State)
@@ -210,7 +244,13 @@ Return: ## PLANNING COMPLETE with plan path
 
 4. **Verify plan exists** at `${QUICK_DIR}/${next_num}-PLAN.md`
 
-5. **(If --full) Spawn plan-checker, handle revision loop (max 2 iterations):**
+5. **Pre-flight plan structure check (gsd-tools):**
+```bash
+PLAN_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify plan-structure "${QUICK_DIR}/${next_num}-PLAN.md")
+```
+Parse the JSON result. If structural issues found, include them in the plan-checker prompt below so it has concrete problems to evaluate rather than searching from scratch.
+
+6. **(If --full) Spawn plan-checker, handle revision loop (max 2 iterations):**
 ```
 Task(
   prompt="
@@ -222,7 +262,11 @@ Task(
 - ${QUICK_DIR}/${next_num}-PLAN.md (Plan to verify)
 </files_to_read>
 
-**Scope:** This is a quick task, not a full phase. Skip checks that require a ROADMAP phase goal.
+<structural_preflight>
+${PLAN_CHECK}
+</structural_preflight>
+
+**Scope:** This is a quick task, not a full phase. Skip checks that require a ROADMAP phase goal. If structural_preflight flagged issues, prioritize evaluating those.
 </verification_context>
 
 <check_dimensions>
@@ -249,7 +293,7 @@ Skip: context compliance (no CONTEXT.md), cross-plan deps (single plan), ROADMAP
 If issues found and iteration < 2: spawn planner revision, then re-check.
 If iteration >= 2: offer force proceed or abort.
 
-6. **Spawn executor (task agent):**
+7. **Spawn executor (task agent):**
 ```
 Task(
   prompt="
@@ -275,9 +319,13 @@ Execute quick task ${next_num}.
 )
 ```
 
-7. **Verify summary exists** at `${QUICK_DIR}/${next_num}-SUMMARY.md`
+8. **Verify summary (gsd-tools):**
+```bash
+VERIFY_RESULT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify-summary "${QUICK_DIR}/${next_num}-SUMMARY.md")
+```
+Parse JSON result. Use `passed` field for go/no-go. Checks summary existence, files created, and commits.
 
-8. **(If --full) Spawn verifier:**
+9. **(If --full) Spawn verifier:**
 ```
 Task(
   prompt="Verify quick task goal achievement.
@@ -295,9 +343,16 @@ Check must_haves against actual codebase. Create VERIFICATION.md at ${QUICK_DIR}
 )
 ```
 
-9. **Update STATE.md** with quick task row in "Quick Tasks Completed" table.
+10. **Post-execution artifact verification (non-blocking):**
+```bash
+ARTIFACT_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify artifacts "${QUICK_DIR}/${next_num}-PLAN.md" 2>/dev/null || echo '{"passed":true}')
+KEYLINK_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify key-links "${QUICK_DIR}/${next_num}-PLAN.md" 2>/dev/null || echo '{"passed":true}')
+```
+Non-blocking: if either check flags issues, include them in the PR description as warnings. Do not halt the pipeline.
 
-10. **Commit artifacts:**
+11. **Update STATE.md** with quick task row in "Quick Tasks Completed" table.
+
+12. **Commit artifacts:**
 ```bash
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(quick-${next_num}): ${issue_title}" --files ${file_list}
 ```
@@ -312,16 +367,41 @@ Only run this step if gsd_route is "gsd:new-milestone".
 
 This is the most complex path. The orchestrator needs to:
 
-1. **Create milestone:** Guide user through /gsd:new-milestone interactively.
-   This requires user input for requirements and scope, so it cannot be fully
-   automated. Present:
-   ```
-   The new-milestone route requires interactive input for requirements and scope.
-   Please run: /gsd:new-milestone
+**Resolve models for milestone agents:**
+```bash
+PLANNER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-planner --raw)
+EXECUTOR_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-executor --raw)
+VERIFIER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-verifier --raw)
+```
 
-   After the milestone is created, run /mgw:run ${ISSUE_NUMBER} again to
-   continue the pipeline through execution.
+1. **Create milestone:** Use `gsd-tools init new-milestone` to gather context, then attempt autonomous roadmap creation from issue data:
+
+   ```bash
+   MILESTONE_INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init new-milestone 2>/dev/null)
    ```
+
+   Extract requirements from structured issue template fields (BLUF, What's Needed, What's Involved) if present.
+
+   If issue body contains sufficient detail (has clear requirements/scope):
+   - Spawn roadmapper agent with issue-derived requirements
+   - After roadmap generation, present to user for confirmation checkpoint:
+     ```
+     AskUserQuestion(
+       header: "Milestone Roadmap Generated",
+       question: "Review the generated ROADMAP.md. Proceed with execution, revise, or switch to interactive mode?",
+       followUp: "Enter: proceed, revise, or interactive"
+     )
+     ```
+
+   If issue body lacks sufficient detail (no clear structure or too vague):
+   - Fall back to interactive mode:
+     ```
+     The new-milestone route requires more detail than the issue provides.
+     Please run: /gsd:new-milestone
+
+     After the milestone is created, run /mgw:run ${ISSUE_NUMBER} again to
+     continue the pipeline through execution.
+     ```
 
    Update pipeline_stage to "planning" (at `${REPO_ROOT}/.mgw/active/`).
 
@@ -358,10 +438,15 @@ Push branch and gather artifacts:
 ```bash
 git push -u origin ${BRANCH_NAME}
 
+# Structured summary data via gsd-tools (returns JSON with one_liner, key_files, tech_added, patterns, decisions)
+SUMMARY_DATA=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs summary-extract "${gsd_artifacts_path}/*SUMMARY*" 2>/dev/null || echo '{}')
+# Also keep raw summary for full context
 SUMMARY=$(cat ${gsd_artifacts_path}/*SUMMARY* 2>/dev/null)
 VERIFICATION=$(cat ${gsd_artifacts_path}/*VERIFICATION* 2>/dev/null)
 COMMITS=$(git log ${DEFAULT_BRANCH}..HEAD --oneline)
 CROSS_REFS=$(cat ${REPO_ROOT}/.mgw/cross-refs.json 2>/dev/null)
+# Progress table for PR details section
+PROGRESS_TABLE=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs progress table --raw 2>/dev/null || echo "")
 ```
 
 Read issue state for context.
@@ -375,13 +460,22 @@ Title: ${issue_title}
 Body: ${issue_body}
 </issue>
 
-<summary>
+<summary_structured>
+${SUMMARY_DATA}
+</summary_structured>
+
+<summary_raw>
 ${SUMMARY}
-</summary>
+</summary_raw>
 
 <verification>
 ${VERIFICATION}
 </verification>
+
+<artifact_warnings>
+${ARTIFACT_CHECK}
+${KEYLINK_CHECK}
+</artifact_warnings>
 
 <commits>
 ${COMMITS}
@@ -394,10 +488,12 @@ ${CROSS_REFS}
 <instructions>
 1. Build PR title: short, prefixed with fix:/feat:/refactor: based on issue labels
 2. Build PR body with:
-   - ## Summary (2-4 bullets)
+   - ## Summary (2-4 bullets, use one_liner from summary_structured if available)
    - Closes #${ISSUE_NUMBER}
-   - ## Changes (file-level grouped by system)
+   - ## Changes (file-level grouped by system, use key_files from summary_structured)
    - ## Cross-References (if any)
+   - If PROGRESS_TABLE is non-empty, include under <details><summary>GSD Progress</summary> block
+   - If artifact_warnings contain failures, include under ## Warnings section
 3. Create PR: gh pr create --title '<title>' --base '${DEFAULT_BRANCH}' --head '${BRANCH_NAME}' --body '<body>'
 4. Post testing procedures as separate PR comment: gh pr comment <pr_number> --body '<testing>'
 5. Return: PR number, PR URL
@@ -428,12 +524,21 @@ rmdir "${REPO_ROOT}/.worktrees/issue" 2>/dev/null
 rmdir "${REPO_ROOT}/.worktrees" 2>/dev/null
 ```
 
+Extract one-liner summary for concise comment:
+```bash
+ONE_LINER=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs summary-extract "${gsd_artifacts_path}/*SUMMARY*" --fields one_liner --raw 2>/dev/null || echo "")
+```
+
 Post completion comment:
 ```
 Task(
   prompt="Post GitHub issue comment.
 Issue: ${ISSUE_NUMBER}
-Comment: **PR Ready** — PR #${PR_NUMBER} created: ${PR_URL}\nTesting procedures posted on the PR.\n\nThis issue will auto-close when the PR is merged.
+Comment: **PR Ready** — PR #${PR_NUMBER} created: ${PR_URL}
+${ONE_LINER ? ONE_LINER : ''}
+Testing procedures posted on the PR.
+
+This issue will auto-close when the PR is merged.
 
 Command: gh issue comment ${ISSUE_NUMBER} --body '<body>'",
   subagent_type="general-purpose",

--- a/.claude/commands/mgw/sync.md
+++ b/.claude/commands/mgw/sync.md
@@ -63,6 +63,18 @@ Classify each issue into:
 - **Drift:** State file says one thing, GitHub says another
 </step>
 
+<step name="health_check">
+**GSD health check (if .planning/ exists):**
+
+For repos with GSD initialized, run a health check and include in the sync report:
+```bash
+if [ -d ".planning" ]; then
+  HEALTH=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs validate health 2>/dev/null || echo '{"status":"unknown"}')
+fi
+```
+This is read-only and additive — health status is included in the sync summary but does not block any reconciliation actions.
+</step>
+
 <step name="reconcile">
 **Take action per classification:**
 
@@ -125,6 +137,7 @@ Completed: ${completed_count} archived
 Stale:     ${stale_count} need attention
 Orphaned:  ${orphaned_count} need attention
 Branches:  ${deleted_count} cleaned up
+${HEALTH ? 'GSD Health: ' + HEALTH.status : ''}
 
 ${details_for_each_non_active_item}
 ```

--- a/.claude/commands/mgw/update.md
+++ b/.claude/commands/mgw/update.md
@@ -98,7 +98,7 @@ Capture comment URL from output.
 
 Update state file: append to comments_posted array:
 ```json
-{ "type": "${update_type}", "timestamp": "${ISO_TIMESTAMP}", "url": "${comment_url}" }
+{ "type": "${update_type}", "timestamp": "$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs current-timestamp --raw)", "url": "${comment_url}" }
 ```
 
 Write updated state back to `.mgw/active/${filename}.json`.

--- a/.claude/commands/mgw/workflows/state.md
+++ b/.claude/commands/mgw/workflows/state.md
@@ -69,7 +69,18 @@ File: `.mgw/active/<number>-<slug>.json`
 
 ## Slug Generation
 
-From issue title: lowercase, replace non-alphanumeric with hyphens, collapse multiple hyphens, trim to 40 chars, strip trailing hyphens.
+Use gsd-tools for consistent slug generation:
+```bash
+SLUG=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs generate-slug "${issue_title}" --raw)
+SLUG="${SLUG:0:40}"  # gsd-tools doesn't truncate; MGW enforces 40-char limit
+```
+
+## Timestamps
+
+Use gsd-tools for ISO timestamp generation:
+```bash
+TIMESTAMP=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs current-timestamp --raw)
+```
 
 ## Cross-Refs Schema
 


### PR DESCRIPTION
## Summary
- **Replace inline bash** with `gsd-tools.cjs` commands for slug generation, model resolution, timestamps, plan/summary/artifact verification across 7 MGW command files
- **Enrich GSD planner context** by passing triage intelligence (scope, security, conflicts), issue comments, and raising issue body cap from 500 → 5000 chars
- **Improve pipeline robustness** with ROADMAP.md scaffolding for uninitialised repos, autonomous milestone roadmap generation, and non-blocking artifact warnings in PRs
- **Enhance PR and comment quality** with structured `summary-extract` data, progress tables, one-liner summaries, and GSD health checks in sync reports

## Changes

### Tier 1 — gsd-tools Replacements (Low Risk)
| File | Change |
|------|--------|
| `workflows/state.md` | Slug → `generate-slug`, added Timestamps section → `current-timestamp` |
| `issue.md` | Slug → `generate-slug` |
| `link.md` | Timestamp → `current-timestamp` |
| `update.md` | Timestamp → `current-timestamp` |
| `run.md` | Summary → `verify-summary`, plan pre-flight → `verify plan-structure`, artifacts → `verify artifacts` + `verify key-links`, milestone models → `resolve-model` |

### Tier 2 — Context Enrichment (Low Risk)
| File | Change |
|------|--------|
| `run.md` | Issue body cap 500→5000, `<triage_context>` + `<issue_comments>` to planner prompt, enriched work-started/PR-ready comments |

### Tier 3 — Structural Fixes (Medium Risk)
| File | Change |
|------|--------|
| `run.md` | ROADMAP.md scaffolding after `init quick` when missing, milestone route autonomy with `init new-milestone` + confirmation checkpoint |
| `sync.md` | GSD health check via `validate health` in sync report |

### Tier 4 — Advanced Integrations (Low-Medium Risk)
| File | Change |
|------|--------|
| `run.md` | `summary-extract` JSON + `progress table` to PR agent, one-liner in completion comment |
| `pr.md` | `summary-extract` structured data, `progress table` in `<details>` block |
| `issue.md` | `history-digest` fed as `<project_history>` to triage analysis |

## Test Plan
- [ ] Verify `gsd-tools` commands return expected output: `generate-slug`, `current-timestamp`, `resolve-model`, `verify-summary`, `verify plan-structure`, `verify artifacts`, `verify key-links`, `summary-extract`, `history-digest`, `progress bar/table`, `validate health`
- [ ] Run `/mgw:run <issue>` on a real issue — confirm triage context reaches planner, ROADMAP scaffolding works for fresh repos
- [ ] Run `/mgw:pr` — confirm structured summary data and progress table appear in PR description
- [ ] Run `/mgw:sync` — confirm health check appears in report
- [ ] Verify step numbering (1–12) in `execute_gsd_quick` is sequential and no steps are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)