### PR TITLE
Add GitHub Actions auto-label workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+slash-commands:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'commands/**'
+          - '.claude/**'
+
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/**'
+
+templates:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'templates/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'README.md'
+          - 'docs/**'
+          - 'CONTRIBUTING.md'
+          - 'CODEOWNERS'
+          - 'CHANGELOG.md'
+          - '*.md'
+
+github-config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,16 @@
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add auto-label workflow using actions/labeler@v5 to label PRs by file paths
- Create labeler.yml mapping commands/, lib/, templates/, docs, and .github/ to labels
- Create corresponding GitHub labels for auto-labeling

Closes #19

## Milestone Context
- **Milestone:** v1 — Community & Collaboration Infrastructure
- **Phase:** 2 — GitHub Repository Configuration
- **Issue:** 5 of 6 in milestone

## Changes
- `.github/workflows/auto-label.yml` — GitHub Actions workflow for PR auto-labeling
- `.github/labeler.yml` — Path-to-label mapping configuration
- GitHub labels created: slash-commands, core, templates, documentation, github-config

## Test Plan
- [ ] Workflow file passes GitHub Actions syntax validation
- [ ] labeler.yml uses correct actions/labeler@v5 configuration format
- [ ] All 5 labels exist on the repository
- [ ] A test PR touching lib/ files gets the `core` label