### PR TITLE
refactor: remove .planning/ writes from MGW commands

### DIFF
--- a/.claude/commands/mgw/project.md
+++ b/.claude/commands/mgw/project.md
@@ -1,6 +1,6 @@
 ---
 name: mgw:project
-description: Initialize a new project — generate AI-driven milestones and issues from project description, write GSD ROADMAP and project state
+description: Initialize a new project — generate AI-driven milestones and issues from project description, persist project state
 argument-hint: ""
 allowed-tools:
   - Bash
@@ -13,9 +13,13 @@ allowed-tools:
 
 <objective>
 Turn a project description into a fully structured GitHub project: milestones created,
-issues scaffolded from AI-generated project-specific content, dependencies labeled, GSD ROADMAP.md
-written, and state persisted. The developer never leaves Claude Code and never does
-project management manually.
+issues scaffolded from AI-generated project-specific content, dependencies labeled, and
+state persisted. The developer never leaves Claude Code and never does project management
+manually.
+
+MGW does NOT write to .planning/ — that directory is owned by GSD. If a project needs
+a ROADMAP.md or other GSD files, run the appropriate GSD command (e.g., /gsd:new-milestone)
+after project initialization.
 
 This command creates structure only. It does NOT trigger execution.
 Run /mgw:milestone to begin executing the first milestone.
@@ -469,90 +473,6 @@ fi
 Store `PROJECT_NUMBER` and `PROJECT_URL` for inclusion in project.json and the summary report.
 </step>
 
-<step name="write_roadmap">
-**Write GSD ROADMAP.md to the target project's .planning/ directory**
-
-```bash
-mkdir -p "${REPO_ROOT}/.planning"
-ROADMAP_PATH="${REPO_ROOT}/.planning/ROADMAP.md"
-
-if [ -f "$ROADMAP_PATH" ]; then
-  echo "ROADMAP.md already exists — skipping (won't overwrite existing GSD work)"
-  ROADMAP_STATUS="skipped (exists)"
-else
-  ROADMAP_STATUS="written"
-fi
-```
-
-If ROADMAP.md does not exist, construct and write it using template data:
-
-The ROADMAP.md must follow the GSD format from `/home/hat/.claude/get-shit-done/templates/roadmap.md`:
-
-**Structure:**
-
-```markdown
-# Roadmap: {PROJECT_NAME}
-
-## Overview
-
-{DESCRIPTION}. This project follows the {GENERATED_TYPE} pipeline.
-
-## Phases
-
-- [ ] **Phase 1: {phase_name}** - {phase_description}
-- [ ] **Phase 2: {phase_name}** - {phase_description}
-...
-
-## Phase Details
-
-### Phase 1: {phase_name}
-**Goal**: {phase_description}
-**Depends on**: Nothing (first phase)
-**Requirements**: (tracked in GitHub — see milestone "{milestone_name}")
-**Success Criteria** (what must be TRUE):
-  1. {issue_title_1}
-  2. {issue_title_2}
-  3. {issue_title_3}
-**Plans**: TBD
-
-Plans:
-- [ ] 01-01: TBD
-
-### Phase 2: {phase_name}
-**Goal**: {phase_description}
-**Depends on**: Phase 1
-**Requirements**: (tracked in GitHub — see milestone "{milestone_name}")
-**Success Criteria** (what must be TRUE):
-  1. {issue_title_1}
-  ...
-**Plans**: TBD
-
-Plans:
-- [ ] 02-01: TBD
-
-## Progress
-
-| Phase | Plans Complete | Status | Completed |
-|-------|----------------|--------|-----------|
-| 1. {phase_name} | 0/1 | Not started | - |
-| 2. {phase_name} | 0/1 | Not started | - |
-...
-```
-
-Generate this content using the template data from `/tmp/mgw-template.json`. Iterate over
-milestones → phases → issues to build each section. Use the Write tool to create
-the file at `$ROADMAP_PATH`.
-
-**Mapping rules:**
-- Each template phase → one GSD phase (numbered globally across milestones)
-- Phase `description` → `**Goal**`
-- Phase `issues[].title` → success criteria bullets (one per issue, as observable behaviors)
-- First phase → `**Depends on**: Nothing (first phase)`, others → `**Depends on**: Phase N-1`
-- Milestone name → Requirements milestone reference
-- Plans section: always `TBD` initially with placeholder `{NN}-01: TBD`
-- Use `$GENERATED_TYPE` (from the AI-generated JSON) in the Overview line instead of a hardcoded template name
-</step>
-
 <step name="write_project_json">
 **Write .mgw/project.json with project state**
 
@@ -671,15 +591,13 @@ Dependencies:
   {list of "#{dependent} blocked-by:#{blocking}" entries}
   (or: "None declared in template")
 
-GSD scaffold:
-  .planning/ROADMAP.md      {written|skipped (exists)}
-
 State:
   .mgw/project.json         written
   .mgw/cross-refs.json      {updated with N entries|unchanged}
 
 Next:
-  /mgw:milestone start      Execute first milestone
+  /gsd:new-milestone         Create GSD ROADMAP.md (if needed)
+  /mgw:milestone start       Execute first milestone
 ```
 
 If any milestones or issues failed to create, include:
@@ -692,7 +610,7 @@ Warnings:
 
 **CRITICAL BOUNDARY (PROJ-05):** This command ends here. It does NOT:
 - Trigger /mgw:milestone or any execution workflow
-- Spawn a GSD agent for ROADMAP.md (writes directly — fast and deterministic)
+- Write to .planning/ (GSD owns that directory — run /gsd:new-milestone to scaffold)
 - Execute any issues or plans
 </step>
 
@@ -708,7 +626,6 @@ Warnings:
 - [ ] Slug-to-number mapping built during Pass 1b
 - [ ] Dependency labels applied (Pass 2) — blocked-by:#N on dependent issues
 - [ ] cross-refs.json updated with dependency entries
-- [ ] .planning/ROADMAP.md written in GSD format (or skipped if exists)
 - [ ] .mgw/project.json written with full project state
 - [ ] Post-init summary displayed
 - [ ] Command does NOT trigger execution (PROJ-05)

--- a/.claude/commands/mgw/run.md
+++ b/.claude/commands/mgw/run.md
@@ -209,19 +209,17 @@ Execute the GSD quick workflow. Read and follow the quick workflow steps:
 1. **Init:** `node ~/.claude/get-shit-done/bin/gsd-tools.cjs init quick "$DESCRIPTION"`
    Parse JSON for: planner_model, executor_model, checker_model, verifier_model, next_num, slug, date, quick_dir, task_dir.
 
-   **Handle missing ROADMAP.md:** Check `roadmap_exists` from init output. If false, create minimal GSD scaffolding so quick workflow has valid state:
+   **Handle missing .planning/:** Check `roadmap_exists` from init output. If false, do NOT
+   create GSD state files — .planning/ is owned by GSD. Only create the quick task
+   directory (GSD agents need it to store plans/summaries):
    ```bash
    if [ "$roadmap_exists" = "false" ]; then
+     echo "NOTE: No .planning/ directory found. GSD manages its own state files."
+     echo "      To create a ROADMAP.md, run /gsd:new-milestone after this pipeline."
      mkdir -p .planning/quick
-     echo '{"model_profile":"balanced","commit_docs":true}' > .planning/config.json
-     cat > .planning/ROADMAP.md << 'HEREDOC'
-   # Roadmap
-   ## v1.0: MGW-Managed
-   Issue-driven development managed by MGW.
-   HEREDOC
    fi
    ```
-   This creates valid GSD state that survives if someone later uses native GSD commands.
+   MGW never writes config.json, ROADMAP.md, or STATE.md — those are GSD-owned files.
 
 2. **Create task directory:**
 ```bash
@@ -254,7 +252,6 @@ ${recent_comments}
 <files_to_read>
 - ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
 - .agents/skills/ (Project skills — if dir exists, list skills, read SKILL.md for each, follow relevant rules)
-- .planning/STATE.md (Project State)
 </files_to_read>
 
 </planning_context>
@@ -340,7 +337,6 @@ Task(
 - ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
 - .agents/skills/ (Project skills — if dir exists, list skills, read SKILL.md for each, follow relevant rules)
 - ${QUICK_DIR}/${next_num}-PLAN.md (Plan)
-- .planning/STATE.md (Project state)
 </files_to_read>
 
 Execute quick task ${next_num}.
@@ -349,7 +345,7 @@ Execute quick task ${next_num}.
 - Execute all tasks in the plan
 - Commit each task atomically
 - Create summary at: ${QUICK_DIR}/${next_num}-SUMMARY.md
-- Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
+- Do NOT update ROADMAP.md or STATE.md (GSD owns .planning/ files)
 </constraints>
 ",
   subagent_type="gsd-executor",
@@ -392,9 +388,7 @@ KEYLINK_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify key-links 
 ```
 Non-blocking: if either check flags issues, include them in the PR description as warnings. Do not halt the pipeline.
 
-11. **Update STATE.md** with quick task row in "Quick Tasks Completed" table.
-
-12. **Commit artifacts:**
+11. **Commit artifacts:**
 ```bash
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(quick-${next_num}): ${issue_title}" --files ${file_list}
 ```

--- a/.claude/commands/mgw/workflows/gsd.md
+++ b/.claude/commands/mgw/workflows/gsd.md
@@ -74,15 +74,13 @@ INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init quick "$DESCRIPTION")
 # Parse: planner_model, executor_model, checker_model, verifier_model,
 #        next_num, slug, date, quick_dir, task_dir, roadmap_exists
 
-# 2. Handle missing ROADMAP.md (quick tasks in non-GSD repos)
+# 2. Handle missing .planning/ (quick tasks in non-GSD repos)
+#    MGW never writes config.json, ROADMAP.md, or STATE.md — those are GSD-owned.
+#    Only create the quick task directory (GSD agents need it).
 if [ "$roadmap_exists" = "false" ]; then
+  echo "NOTE: No .planning/ directory found. GSD manages its own state files."
+  echo "      To create a ROADMAP.md, run /gsd:new-milestone after this pipeline."
   mkdir -p .planning/quick
-  echo '{"model_profile":"balanced","commit_docs":true}' > .planning/config.json
-  cat > .planning/ROADMAP.md << 'HEREDOC'
-# Roadmap
-## v1.0: MGW-Managed
-Issue-driven development managed by MGW.
-HEREDOC
 fi
 
 # 3. Create task directory

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ So I built MGW to be the responsible adult in the room. I point it at an issue, 
 
 | Command | What it does |
 |---------|-------------|
-| `/mgw:project` | Scaffold a new project — generate milestones, issues, and GSD ROADMAP from a description |
+| `/mgw:project` | Scaffold a new project — generate milestones, issues, and persist project state |
 | `/mgw:init` | Bootstrap repo for MGW — creates .mgw/ state, GitHub templates, gitignore entries |
 | `/mgw:issues` | Browse and filter your GitHub issues |
 | `/mgw:issue <n>` | Deep triage — scope analysis, security review, GSD route recommendation |

--- a/commands/project.md
+++ b/commands/project.md
@@ -1,6 +1,6 @@
 ---
 name: mgw:project
-description: Initialize a new project — generate AI-driven milestones and issues from project description, write GSD ROADMAP and project state
+description: Initialize a new project — generate AI-driven milestones and issues from project description, persist project state
 argument-hint: ""
 allowed-tools:
   - Bash
@@ -13,9 +13,13 @@ allowed-tools:
 
 <objective>
 Turn a project description into a fully structured GitHub project: milestones created,
-issues scaffolded from AI-generated project-specific content, dependencies labeled, GSD ROADMAP.md
-written, and state persisted. The developer never leaves Claude Code and never does
-project management manually.
+issues scaffolded from AI-generated project-specific content, dependencies labeled, and
+state persisted. The developer never leaves Claude Code and never does project management
+manually.
+
+MGW does NOT write to .planning/ — that directory is owned by GSD. If a project needs
+a ROADMAP.md or other GSD files, run the appropriate GSD command (e.g., /gsd:new-milestone)
+after project initialization.
 
 This command creates structure only. It does NOT trigger execution.
 Run /mgw:milestone to begin executing the first milestone.
@@ -469,90 +473,6 @@ fi
 Store `PROJECT_NUMBER` and `PROJECT_URL` for inclusion in project.json and the summary report.
 </step>
 
-<step name="write_roadmap">
-**Write GSD ROADMAP.md to the target project's .planning/ directory**
-
-```bash
-mkdir -p "${REPO_ROOT}/.planning"
-ROADMAP_PATH="${REPO_ROOT}/.planning/ROADMAP.md"
-
-if [ -f "$ROADMAP_PATH" ]; then
-  echo "ROADMAP.md already exists — skipping (won't overwrite existing GSD work)"
-  ROADMAP_STATUS="skipped (exists)"
-else
-  ROADMAP_STATUS="written"
-fi
-```
-
-If ROADMAP.md does not exist, construct and write it using template data:
-
-The ROADMAP.md must follow the GSD format from `/home/hat/.claude/get-shit-done/templates/roadmap.md`:
-
-**Structure:**
-
-```markdown
-# Roadmap: {PROJECT_NAME}
-
-## Overview
-
-{DESCRIPTION}. This project follows the {GENERATED_TYPE} pipeline.
-
-## Phases
-
-- [ ] **Phase 1: {phase_name}** - {phase_description}
-- [ ] **Phase 2: {phase_name}** - {phase_description}
-...
-
-## Phase Details
-
-### Phase 1: {phase_name}
-**Goal**: {phase_description}
-**Depends on**: Nothing (first phase)
-**Requirements**: (tracked in GitHub — see milestone "{milestone_name}")
-**Success Criteria** (what must be TRUE):
-  1. {issue_title_1}
-  2. {issue_title_2}
-  3. {issue_title_3}
-**Plans**: TBD
-
-Plans:
-- [ ] 01-01: TBD
-
-### Phase 2: {phase_name}
-**Goal**: {phase_description}
-**Depends on**: Phase 1
-**Requirements**: (tracked in GitHub — see milestone "{milestone_name}")
-**Success Criteria** (what must be TRUE):
-  1. {issue_title_1}
-  ...
-**Plans**: TBD
-
-Plans:
-- [ ] 02-01: TBD
-
-## Progress
-
-| Phase | Plans Complete | Status | Completed |
-|-------|----------------|--------|-----------|
-| 1. {phase_name} | 0/1 | Not started | - |
-| 2. {phase_name} | 0/1 | Not started | - |
-...
-```
-
-Generate this content using the template data from `/tmp/mgw-template.json`. Iterate over
-milestones → phases → issues to build each section. Use the Write tool to create
-the file at `$ROADMAP_PATH`.
-
-**Mapping rules:**
-- Each template phase → one GSD phase (numbered globally across milestones)
-- Phase `description` → `**Goal**`
-- Phase `issues[].title` → success criteria bullets (one per issue, as observable behaviors)
-- First phase → `**Depends on**: Nothing (first phase)`, others → `**Depends on**: Phase N-1`
-- Milestone name → Requirements milestone reference
-- Plans section: always `TBD` initially with placeholder `{NN}-01: TBD`
-- Use `$GENERATED_TYPE` (from the AI-generated JSON) in the Overview line instead of a hardcoded template name
-</step>
-
 <step name="write_project_json">
 **Write .mgw/project.json with project state**
 
@@ -671,15 +591,13 @@ Dependencies:
   {list of "#{dependent} blocked-by:#{blocking}" entries}
   (or: "None declared in template")
 
-GSD scaffold:
-  .planning/ROADMAP.md      {written|skipped (exists)}
-
 State:
   .mgw/project.json         written
   .mgw/cross-refs.json      {updated with N entries|unchanged}
 
 Next:
-  /mgw:milestone start      Execute first milestone
+  /gsd:new-milestone         Create GSD ROADMAP.md (if needed)
+  /mgw:milestone start       Execute first milestone
 ```
 
 If any milestones or issues failed to create, include:
@@ -692,7 +610,7 @@ Warnings:
 
 **CRITICAL BOUNDARY (PROJ-05):** This command ends here. It does NOT:
 - Trigger /mgw:milestone or any execution workflow
-- Spawn a GSD agent for ROADMAP.md (writes directly — fast and deterministic)
+- Write to .planning/ (GSD owns that directory — run /gsd:new-milestone to scaffold)
 - Execute any issues or plans
 </step>
 
@@ -708,7 +626,6 @@ Warnings:
 - [ ] Slug-to-number mapping built during Pass 1b
 - [ ] Dependency labels applied (Pass 2) — blocked-by:#N on dependent issues
 - [ ] cross-refs.json updated with dependency entries
-- [ ] .planning/ROADMAP.md written in GSD format (or skipped if exists)
 - [ ] .mgw/project.json written with full project state
 - [ ] Post-init summary displayed
 - [ ] Command does NOT trigger execution (PROJ-05)

--- a/commands/run.md
+++ b/commands/run.md
@@ -209,19 +209,17 @@ Execute the GSD quick workflow. Read and follow the quick workflow steps:
 1. **Init:** `node ~/.claude/get-shit-done/bin/gsd-tools.cjs init quick "$DESCRIPTION"`
    Parse JSON for: planner_model, executor_model, checker_model, verifier_model, next_num, slug, date, quick_dir, task_dir.
 
-   **Handle missing ROADMAP.md:** Check `roadmap_exists` from init output. If false, create minimal GSD scaffolding so quick workflow has valid state:
+   **Handle missing .planning/:** Check `roadmap_exists` from init output. If false, do NOT
+   create GSD state files — .planning/ is owned by GSD. Only create the quick task
+   directory (GSD agents need it to store plans/summaries):
    ```bash
    if [ "$roadmap_exists" = "false" ]; then
+     echo "NOTE: No .planning/ directory found. GSD manages its own state files."
+     echo "      To create a ROADMAP.md, run /gsd:new-milestone after this pipeline."
      mkdir -p .planning/quick
-     echo '{"model_profile":"balanced","commit_docs":true}' > .planning/config.json
-     cat > .planning/ROADMAP.md << 'HEREDOC'
-   # Roadmap
-   ## v1.0: MGW-Managed
-   Issue-driven development managed by MGW.
-   HEREDOC
    fi
    ```
-   This creates valid GSD state that survives if someone later uses native GSD commands.
+   MGW never writes config.json, ROADMAP.md, or STATE.md — those are GSD-owned files.
 
 2. **Create task directory:**
 ```bash
@@ -254,7 +252,6 @@ ${recent_comments}
 <files_to_read>
 - ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
 - .agents/skills/ (Project skills — if dir exists, list skills, read SKILL.md for each, follow relevant rules)
-- .planning/STATE.md (Project State)
 </files_to_read>
 
 </planning_context>
@@ -340,7 +337,6 @@ Task(
 - ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
 - .agents/skills/ (Project skills — if dir exists, list skills, read SKILL.md for each, follow relevant rules)
 - ${QUICK_DIR}/${next_num}-PLAN.md (Plan)
-- .planning/STATE.md (Project state)
 </files_to_read>
 
 Execute quick task ${next_num}.
@@ -349,7 +345,7 @@ Execute quick task ${next_num}.
 - Execute all tasks in the plan
 - Commit each task atomically
 - Create summary at: ${QUICK_DIR}/${next_num}-SUMMARY.md
-- Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
+- Do NOT update ROADMAP.md or STATE.md (GSD owns .planning/ files)
 </constraints>
 ",
   subagent_type="gsd-executor",
@@ -392,9 +388,7 @@ KEYLINK_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify key-links 
 ```
 Non-blocking: if either check flags issues, include them in the PR description as warnings. Do not halt the pipeline.
 
-11. **Update STATE.md** with quick task row in "Quick Tasks Completed" table.
-
-12. **Commit artifacts:**
+11. **Commit artifacts:**
 ```bash
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(quick-${next_num}): ${issue_title}" --files ${file_list}
 ```


### PR DESCRIPTION
## Summary
- Removed all 4 `.planning/` write violations from MGW commands, eliminating bidirectional coupling with GSD
- MGW no longer writes `config.json`, `ROADMAP.md`, or `STATE.md` — those files are now exclusively owned by GSD
- Kept `.planning/quick/` directory creation (mkdir only) since GSD agents need it for plan/summary storage
- Added graceful messaging when `.planning/` is missing, directing users to `/gsd:new-milestone`

Closes #35

## Milestone Context
- **Milestone:** v1 — Pipeline Intelligence
- **Phase:** 7 — Pipeline Fixes
- **Issue:** 1 of 4 in milestone

## Changes
- **commands/project.md** — removed entire `write_roadmap` step (82 lines), updated description/objective/report/success-criteria to reflect no `.planning/` writes
- **commands/run.md** — replaced `.planning/` scaffolding (config.json + ROADMAP.md) with mkdir-only + user message; removed STATE.md update step; removed `.planning/STATE.md` from executor/planner `files_to_read`
- **.claude/commands/mgw/project.md** — mirror of commands/project.md
- **.claude/commands/mgw/run.md** — mirror of commands/run.md
- **.claude/commands/mgw/workflows/gsd.md** — updated GSD Quick Pipeline Pattern to remove config.json + ROADMAP.md writes
- **README.md** — updated `/mgw:project` description to remove "GSD ROADMAP" reference

## Test Plan
- [ ] Verify `grep -r 'config\.json\|ROADMAP\.md\|STATE\.md' commands/ .claude/commands/mgw/` shows no write operations (only read references or documentation)
- [ ] Verify `mkdir -p .planning/quick` is the only `.planning/` mutation remaining
- [ ] Verify mirrors match: `diff commands/project.md .claude/commands/mgw/project.md && diff commands/run.md .claude/commands/mgw/run.md`
- [ ] Verify the `write_roadmap` step no longer exists in project.md
- [ ] Confirm project.md success criteria no longer references `.planning/ROADMAP.md`