### PR TITLE
feat: comment-aware pipeline for MGW

### DIFF
--- a/.claude/commands/mgw/issue.md
+++ b/.claude/commands/mgw/issue.md
@@ -66,6 +66,27 @@ gh issue view $ISSUE_NUMBER --json number,title,body,labels,assignees,state,comm
 If issue not found → error: "Issue #$ISSUE_NUMBER not found in this repo."
 
 Store as $ISSUE_DATA.
+
+**Capture comment tracking snapshot:**
+
+Record the current comment count and timestamp of the most recent comment. These
+are stored in the triage state and used by run.md's pre-flight comment check to
+detect new comments posted between triage and execution.
+
+```bash
+COMMENT_COUNT=$(echo "$ISSUE_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('comments', [])))")
+LAST_COMMENT_AT=$(echo "$ISSUE_DATA" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+comments = d.get('comments', [])
+if comments:
+    print(comments[-1].get('createdAt', ''))
+else:
+    print('')
+" 2>/dev/null || echo "")
+```
+
+Store $COMMENT_COUNT and $LAST_COMMENT_AT for use in the write_state step.
 </step>
 
 <step name="assign_self">
@@ -223,6 +244,8 @@ Write to `.mgw/active/${ISSUE_NUMBER}-${slug}.json` using the schema from state.
 Populate:
 - issue: from $ISSUE_DATA
 - triage: from analysis report
+- triage.last_comment_count: from $COMMENT_COUNT (captured in fetch_issue step)
+- triage.last_comment_at: from $LAST_COMMENT_AT (captured in fetch_issue step, null if no comments)
 - gsd_route: confirmed or overridden route
 - pipeline_stage: "triaged"
 - All other fields: defaults (empty arrays, null)
@@ -257,11 +280,12 @@ Consider closing or commenting on the issue with your reasoning.
 
 <success_criteria>
 - [ ] Issue fetched from GitHub via gh CLI
+- [ ] Comment tracking snapshot captured (count + last timestamp)
 - [ ] Self-assigned if not already
 - [ ] Analysis agent spawned and returned structured report
 - [ ] Scope, validity, security, conflicts all assessed
 - [ ] GSD route recommended with reasoning
 - [ ] User confirms, overrides, or rejects
-- [ ] State file written to .mgw/active/ (if accepted)
+- [ ] State file written to .mgw/active/ (if accepted) with comment tracking fields
 - [ ] Next steps offered
 </success_criteria>

--- a/.claude/commands/mgw/review.md
+++ b/.claude/commands/mgw/review.md
@@ -1,0 +1,231 @@
+---
+name: mgw:review
+description: Review and classify new comments on a GitHub issue since last triage
+argument-hint: "<issue-number>"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Task
+  - AskUserQuestion
+---
+
+<objective>
+Standalone comment review for a triaged issue. Fetches new comments posted since
+triage, classifies them (material/informational/blocking), and updates the state
+file accordingly.
+
+Use this when you want to check for stakeholder feedback before running the pipeline,
+or to review comments on a blocked issue before unblocking it.
+</objective>
+
+<execution_context>
+@~/.claude/commands/mgw/workflows/state.md
+@~/.claude/commands/mgw/workflows/github.md
+@~/.claude/commands/mgw/workflows/gsd.md
+@~/.claude/commands/mgw/workflows/validation.md
+</execution_context>
+
+<context>
+Issue number: $ARGUMENTS
+
+State: .mgw/active/ (must exist — issue must be triaged first)
+</context>
+
+<process>
+
+<step name="validate_and_load">
+**Validate input and load state:**
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Parse $ARGUMENTS for issue number. If missing:
+```
+AskUserQuestion(
+  header: "Issue Number Required",
+  question: "Which issue number do you want to review comments for?",
+  followUp: "Enter the GitHub issue number (e.g., 42)"
+)
+```
+
+Load state file: `${REPO_ROOT}/.mgw/active/${ISSUE_NUMBER}-*.json`
+
+If no state file exists:
+```
+Issue #${ISSUE_NUMBER} hasn't been triaged yet.
+Run /mgw:issue ${ISSUE_NUMBER} first, then review comments.
+```
+</step>
+
+<step name="fetch_comments">
+**Fetch current comment state from GitHub:**
+
+```bash
+CURRENT_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"
+
+if [ -z "$STORED_COMMENTS" ] || [ "$STORED_COMMENTS" = "null" ]; then
+  STORED_COMMENTS=0
+fi
+
+NEW_COUNT=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+```
+
+If no new comments (`NEW_COUNT <= 0`):
+```
+No new comments on #${ISSUE_NUMBER} since triage (${STORED_COMMENTS} comments at triage, ${CURRENT_COMMENTS} now).
+```
+Stop.
+
+If new comments exist, fetch them:
+```bash
+NEW_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments \
+  --jq "[.comments[-${NEW_COUNT}:]] | .[] | {author: .author.login, body: .body, createdAt: .createdAt}" 2>/dev/null)
+```
+</step>
+
+<step name="classify_comments">
+**Spawn classification agent:**
+
+```
+Task(
+  prompt="
+<files_to_read>
+- ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
+</files_to_read>
+
+Classify new comments on GitHub issue #${ISSUE_NUMBER}.
+
+<issue_context>
+Title: ${issue_title}
+Current pipeline stage: ${pipeline_stage}
+GSD Route: ${gsd_route}
+Triage scope: ${triage.scope}
+</issue_context>
+
+<new_comments>
+${NEW_COMMENTS}
+</new_comments>
+
+<classification_rules>
+Classify each comment (and the overall batch) into ONE of:
+
+- **material** — Comment changes scope, requirements, acceptance criteria, or design.
+  Examples: 'Actually we also need to handle X', 'Changed the requirement to Y',
+  'Don't forget about edge case Z'.
+
+- **informational** — Status update, acknowledgment, question that doesn't change scope, +1.
+  Examples: 'Looks good', 'Thanks for picking this up', 'What's the ETA?', '+1'.
+
+- **blocking** — Explicit instruction to stop or wait. Must contain clear hold language.
+  Examples: 'Don't work on this yet', 'Hold off', 'Blocked by external dependency',
+  'Wait for design review'.
+
+If ANY comment in the batch is blocking, overall classification is blocking.
+If ANY comment is material (and none blocking), overall classification is material.
+Otherwise, informational.
+</classification_rules>
+
+<output_format>
+Return ONLY valid JSON:
+{
+  \"classification\": \"material|informational|blocking\",
+  \"reasoning\": \"Brief explanation of why this classification was chosen\",
+  \"per_comment\": [
+    {
+      \"author\": \"username\",
+      \"snippet\": \"first 100 chars of comment\",
+      \"classification\": \"material|informational|blocking\"
+    }
+  ],
+  \"new_requirements\": [\"list of new requirements if material, empty array otherwise\"],
+  \"blocking_reason\": \"reason if blocking, empty string otherwise\"
+}
+</output_format>
+",
+  subagent_type="general-purpose",
+  description="Classify comments on #${ISSUE_NUMBER}"
+)
+```
+</step>
+
+<step name="present_and_act">
+**Present classification and offer actions:**
+
+Display the classification result:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ MGW ► COMMENT REVIEW — #${ISSUE_NUMBER}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+New comments: ${NEW_COUNT} since triage
+Classification: ${classification}
+Reasoning: ${reasoning}
+
+${per_comment_table}
+
+${if material: 'New requirements detected:\n' + new_requirements}
+${if blocking: 'Blocking reason: ' + blocking_reason}
+```
+
+Offer actions based on classification:
+
+**If informational:**
+```
+AskUserQuestion(
+  header: "Informational Comments",
+  question: "Mark comments as reviewed and update state?",
+  options: [
+    { label: "Yes", description: "Update last_comment_count, continue" },
+    { label: "No", description: "Keep current state, don't update count" }
+  ]
+)
+```
+If yes: update `triage.last_comment_count` to $CURRENT_COMMENTS in state file.
+
+**If material:**
+```
+AskUserQuestion(
+  header: "Material Comments Detected",
+  question: "How should MGW handle the scope change?",
+  options: [
+    { label: "Acknowledge and continue", description: "Update state with new requirements, keep current route" },
+    { label: "Re-triage", description: "Run /mgw:issue to re-analyze with new context" },
+    { label: "Ignore", description: "Don't update state" }
+  ]
+)
+```
+If acknowledge: update `triage.last_comment_count` and store new_requirements in state.
+If re-triage: suggest running `/mgw:issue ${ISSUE_NUMBER}` to re-triage.
+
+**If blocking:**
+```
+AskUserQuestion(
+  header: "Blocking Comment Detected",
+  question: "Block the pipeline for this issue?",
+  options: [
+    { label: "Block", description: "Set pipeline_stage to 'blocked'" },
+    { label: "Override", description: "Ignore blocker, keep current stage" },
+    { label: "Review", description: "I'll review the comments manually" }
+  ]
+)
+```
+If block: update `pipeline_stage = "blocked"` and `triage.last_comment_count` in state.
+If override: update `triage.last_comment_count` only, keep pipeline_stage.
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Issue state loaded from .mgw/active/
+- [ ] Current comment count fetched from GitHub
+- [ ] New comments identified (delta from stored count)
+- [ ] Classification agent spawned and returned structured result
+- [ ] Classification presented to user with per-comment breakdown
+- [ ] User chose action (acknowledge/re-triage/block/ignore)
+- [ ] State file updated according to user choice
+</success_criteria>

--- a/.claude/commands/mgw/run.md
+++ b/.claude/commands/mgw/run.md
@@ -76,6 +76,7 @@ If no state file exists → issue not triaged yet. Run triage inline:
 If state file exists → load it. Check pipeline_stage:
   - "triaged" → proceed to GSD execution
   - "planning" / "executing" → resume from where we left off
+  - "blocked" → "Pipeline for #${ISSUE_NUMBER} is blocked by a stakeholder comment. Review the issue comments, resolve the blocker, then re-run."
   - "pr-created" / "done" → "Pipeline already completed for #${ISSUE_NUMBER}. Run /mgw:sync to reconcile."
 </step>
 
@@ -122,6 +123,99 @@ Add cross-ref (at `${REPO_ROOT}/.mgw/cross-refs.json`): issue → branch.
 - File operations, git commands, and agent work use **relative paths** (CWD = worktree)
 - `.mgw/` state operations use **absolute paths**: `${REPO_ROOT}/.mgw/`
   (`.mgw/` is gitignored — it only exists in the main repo, not the worktree)
+</step>
+
+<step name="preflight_comment_check">
+**Pre-flight comment check — detect new comments since triage:**
+
+Before GSD execution begins, check if new comments have been posted on the issue
+since triage. This prevents executing against a stale plan when stakeholders have
+posted material changes, blockers, or scope updates.
+
+```bash
+# Fetch current comment count from GitHub
+CURRENT_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"  # From state file
+
+# If stored count is missing (pre-comment-tracking state), skip check
+if [ -z "$STORED_COMMENTS" ] || [ "$STORED_COMMENTS" = "null" ] || [ "$STORED_COMMENTS" = "0" ]; then
+  STORED_COMMENTS=0
+fi
+```
+
+If new comments detected (`CURRENT_COMMENTS > STORED_COMMENTS`):
+
+1. **Fetch new comment bodies:**
+```bash
+NEW_COUNT=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+NEW_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments \
+  --jq "[.comments[-${NEW_COUNT}:]] | .[] | {author: .author.login, body: .body, createdAt: .createdAt}" 2>/dev/null)
+```
+
+2. **Spawn classification agent:**
+```
+Task(
+  prompt="
+<files_to_read>
+- ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
+</files_to_read>
+
+Classify new comments on GitHub issue #${ISSUE_NUMBER}.
+
+<issue_context>
+Title: ${issue_title}
+Current pipeline stage: ${pipeline_stage}
+GSD Route: ${gsd_route}
+Triage scope: ${triage.scope}
+</issue_context>
+
+<new_comments>
+${NEW_COMMENTS}
+</new_comments>
+
+<classification_rules>
+Classify each comment (and the overall batch) into ONE of:
+
+- **material** — Comment changes scope, requirements, acceptance criteria, or design.
+  Examples: 'Actually we also need to handle X', 'Changed the requirement to Y',
+  'Don't forget about edge case Z'.
+
+- **informational** — Status update, acknowledgment, question that doesn't change scope, +1.
+  Examples: 'Looks good', 'Thanks for picking this up', 'What's the ETA?', '+1'.
+
+- **blocking** — Explicit instruction to stop or wait. Must contain clear hold language.
+  Examples: 'Don't work on this yet', 'Hold off', 'Blocked by external dependency',
+  'Wait for design review'.
+
+If ANY comment in the batch is blocking, overall classification is blocking.
+If ANY comment is material (and none blocking), overall classification is material.
+Otherwise, informational.
+</classification_rules>
+
+<output_format>
+Return ONLY valid JSON:
+{
+  \"classification\": \"material|informational|blocking\",
+  \"reasoning\": \"Brief explanation of why this classification was chosen\",
+  \"new_requirements\": [\"list of new requirements if material, empty array otherwise\"],
+  \"blocking_reason\": \"reason if blocking, empty string otherwise\"
+}
+</output_format>
+",
+  subagent_type="general-purpose",
+  description="Classify comments on #${ISSUE_NUMBER}"
+)
+```
+
+3. **React based on classification:**
+
+| Classification | Action |
+|---------------|--------|
+| **informational** | Log: "MGW: ${NEW_COUNT} new comment(s) reviewed — informational, continuing." Update `triage.last_comment_count` in state file. Continue pipeline. |
+| **material** | Log: "MGW: Material comment(s) detected — scope may have changed." Update state: add new_requirements to triage context. Update `triage.last_comment_count`. Re-read issue body for updated requirements. Continue with enriched context (pass new_requirements to planner). |
+| **blocking** | Log: "MGW: Blocking comment detected — pipeline paused." Update state: `pipeline_stage = "blocked"`. Post comment on issue: `> **MGW** . \`pipeline-blocked\` . Blocked by stakeholder comment. Reason: ${blocking_reason}`. Stop pipeline execution. |
+
+If no new comments detected, continue normally.
 </step>
 
 <step name="post_triage_update">
@@ -759,6 +853,7 @@ Next:
 <success_criteria>
 - [ ] Issue number validated and state loaded (or triage run first)
 - [ ] Isolated worktree created (.worktrees/ gitignored)
+- [ ] Pre-flight comment check performed (new comments classified before execution)
 - [ ] Structured triage comment posted on issue (scope, route, files, security)
 - [ ] GSD pipeline executed in worktree (quick or milestone route)
 - [ ] Execution-complete comment posted on issue (commits, changes, test status)

--- a/.claude/commands/mgw/sync.md
+++ b/.claude/commands/mgw/sync.md
@@ -56,6 +56,15 @@ git ls-remote --heads origin ${BRANCH_NAME} | grep -q . && echo "remote" || echo
 
 # Worktree existence
 git worktree list | grep -q "${BRANCH_NAME}" && echo "worktree" || echo "no-worktree"
+
+# Comment delta (detect unreviewed comments since triage)
+CURRENT_COMMENTS=$(gh issue view ${NUMBER} --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"  # From state file, may be null/missing
+if [ -n "$STORED_COMMENTS" ] && [ "$STORED_COMMENTS" != "null" ]; then
+  COMMENT_DELTA=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+else
+  COMMENT_DELTA=0  # No baseline — skip comment drift
+fi
 ```
 
 Classify each issue into:
@@ -64,6 +73,7 @@ Classify each issue into:
 - **Orphaned:** Branch deleted but work incomplete
 - **Active:** Still in progress, everything consistent
 - **Drift:** State file says one thing, GitHub says another
+- **Unreviewed comments:** COMMENT_DELTA > 0 — new comments posted since triage that haven't been classified
 </step>
 
 <step name="health_check">
@@ -139,10 +149,12 @@ Active:    ${active_count} issues in progress
 Completed: ${completed_count} archived
 Stale:     ${stale_count} need attention
 Orphaned:  ${orphaned_count} need attention
+Comments:  ${comment_drift_count} issues with unreviewed comments
 Branches:  ${deleted_count} cleaned up
 ${HEALTH ? 'GSD Health: ' + HEALTH.status : ''}
 
 ${details_for_each_non_active_item}
+${comment_drift_details ? 'Unreviewed comments:\n' + comment_drift_details : ''}
 ```
 </step>
 
@@ -151,9 +163,10 @@ ${details_for_each_non_active_item}
 <success_criteria>
 - [ ] All .mgw/active/ files scanned
 - [ ] GitHub state checked for each issue, PR, branch
+- [ ] Comment delta checked for each active issue
 - [ ] Completed items moved to .mgw/completed/
 - [ ] Lingering worktrees cleaned up for completed items
 - [ ] Branch deletion offered for completed items
-- [ ] Stale/orphaned/drift items flagged
+- [ ] Stale/orphaned/drift items flagged (including comment drift)
 - [ ] Summary presented
 </success_criteria>

--- a/.claude/commands/mgw/workflows/github.md
+++ b/.claude/commands/mgw/workflows/github.md
@@ -35,6 +35,28 @@ Used by staleness detection to compare GitHub state with local state.
 gh issue view ${ISSUE_NUMBER} --json updatedAt -q .updatedAt
 ```
 
+### Get Comment Count
+Used by comment tracking to get the current number of comments on an issue.
+```bash
+gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments | length'
+```
+
+### Get Recent Comments
+Used by pre-flight comment check and review command to fetch new comments since triage.
+```bash
+# Fetch last N comments with author, body, and timestamp
+NEW_COUNT=$((CURRENT_COMMENTS - STORED_COMMENTS))
+gh issue view ${ISSUE_NUMBER} --json comments \
+  --jq "[.comments[-${NEW_COUNT}:]] | .[] | {author: .author.login, body: .body, createdAt: .createdAt}"
+```
+
+### Get Last Comment Timestamp
+Used during triage to snapshot the most recent comment timestamp.
+```bash
+gh issue view ${ISSUE_NUMBER} --json comments \
+  --jq '.comments[-1].createdAt // empty'
+```
+
 ## Issue Mutations
 
 ### Assign to Self
@@ -238,6 +260,7 @@ Release is created as draft — user reviews and publishes manually.
 | Section | Referenced By |
 |---------|-------------|
 | Issue Operations | issue.md, run.md, issues.md, sync.md, milestone.md, next.md |
+| Comment Operations | issue.md (triage snapshot), run.md (pre-flight check), sync.md (drift), review.md |
 | Issue Mutations | issue.md, update.md, run.md, init.md, milestone.md |
 | Milestone Operations | project.md, milestone.md |
 | Dependency Labels | project.md |

--- a/.claude/commands/mgw/workflows/gsd.md
+++ b/.claude/commands/mgw/workflows/gsd.md
@@ -62,7 +62,49 @@ CHECKER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd
 | `gsd-executor` | Agents that write application code | Plan task execution |
 | `gsd-verifier` | Post-execution verification agents | Goal achievement checks |
 | `gsd-plan-checker` | Plan quality review agents | Plan structure and coverage review |
-| `general-purpose` | Utility agents (no code execution) | Comments, PR body, analysis, triage |
+| `general-purpose` | Utility agents (no code execution) | Comments, PR body, analysis, triage, comment classification |
+
+## Comment Classification Pattern
+
+Used by `/mgw:run` (pre-flight check) and `/mgw:review` (standalone) to classify
+new comments as material, informational, or blocking.
+
+```
+Task(
+  prompt="
+<files_to_read>
+- ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
+</files_to_read>
+
+Classify new comments on GitHub issue #${ISSUE_NUMBER}.
+
+<issue_context>
+Title: ${issue_title}
+Current pipeline stage: ${pipeline_stage}
+GSD Route: ${gsd_route}
+Triage scope: ${triage.scope}
+</issue_context>
+
+<new_comments>
+${NEW_COMMENTS}
+</new_comments>
+
+<classification_rules>
+- material — changes scope, requirements, acceptance criteria, or design
+- informational — status update, acknowledgment, question, +1
+- blocking — explicit instruction to stop or wait
+
+Priority: blocking > material > informational
+</classification_rules>
+
+<output_format>
+Return ONLY valid JSON with: classification, reasoning, new_requirements, blocking_reason
+</output_format>
+",
+  subagent_type="general-purpose",
+  description="Classify comments on #${ISSUE_NUMBER}"
+)
+```
 
 ## GSD Quick Pipeline Pattern
 
@@ -191,7 +233,8 @@ KEYLINK_CHECK=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify key-links 
 
 | Pattern | Referenced By |
 |---------|-------------|
-| Standard spawn template | run.md, issue.md, pr.md |
+| Standard spawn template | run.md, issue.md, pr.md, review.md |
+| Comment classification | run.md (pre-flight), review.md (standalone) |
 | Quick pipeline | run.md |
 | Milestone pipeline | run.md |
 | Model resolution | run.md |

--- a/.claude/commands/mgw/workflows/state.md
+++ b/.claude/commands/mgw/workflows/state.md
@@ -129,6 +129,64 @@ check_batch_staleness() {
 - When the check fails (network, API limit, error): **continue silently** — never let staleness detection prevent command execution
 - Scope: covers **both milestone-level and issue-level state**
 
+## Comment Tracking
+
+Comment tracking detects new comments posted on an issue between triage and execution.
+The `triage.last_comment_count` and `triage.last_comment_at` fields are populated during
+triage (issue.md) and checked before GSD execution begins (run.md).
+
+### Comment Tracking Fields
+
+| Field | Type | Set By | Description |
+|-------|------|--------|-------------|
+| `triage.last_comment_count` | number | issue.md | Total comment count at triage time |
+| `triage.last_comment_at` | string\|null | issue.md | ISO timestamp of most recent comment at triage time |
+
+### Pre-Flight Comment Check
+
+Before GSD execution starts, run.md compares current comment count against the stored
+count. If new comments are detected, they are classified before proceeding:
+
+```bash
+# Fetch current comment state from GitHub
+CURRENT_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments --jq '.comments | length')
+STORED_COMMENTS="${triage.last_comment_count}"
+
+if [ "$CURRENT_COMMENTS" -gt "$STORED_COMMENTS" ]; then
+  # New comments detected — fetch and classify
+  NEW_COMMENT_BODIES=$(gh issue view $ISSUE_NUMBER --json comments \
+    --jq "[.comments[-$(($CURRENT_COMMENTS - $STORED_COMMENTS)):]] | .[].body")
+fi
+```
+
+### Comment Classification
+
+New comments are classified by a general-purpose agent into one of three categories:
+
+| Classification | Meaning | Pipeline Action |
+|---------------|---------|-----------------|
+| **material** | Changes scope, requirements, or acceptance criteria | Flag for re-triage — update state, re-run triage analysis |
+| **informational** | Status update, +1, question, acknowledgment | Log and continue — no pipeline impact |
+| **blocking** | Explicit "don't work on this yet", "hold", "wait" | Pause pipeline — set pipeline_stage to "blocked" |
+
+The classification agent receives the new comment bodies and the issue context, and returns
+a JSON result:
+
+```json
+{
+  "classification": "material|informational|blocking",
+  "reasoning": "Brief explanation",
+  "new_requirements": ["list of new requirements if material"],
+  "blocking_reason": "reason if blocking"
+}
+```
+
+### Comment Delta in Drift Detection
+
+sync.md includes comment delta as a drift signal. If the current comment count differs
+from `triage.last_comment_count`, the issue is flagged as having unreviewed comments
+in the sync report.
+
 ## Issue State Schema
 
 File: `.mgw/active/<number>-<slug>.json`
@@ -146,7 +204,9 @@ File: `.mgw/active/<number>-<slug>.json`
     "scope": { "files": 0, "systems": [] },
     "validity": "pending|confirmed|invalid",
     "security_notes": "",
-    "conflicts": []
+    "conflicts": [],
+    "last_comment_count": 0,
+    "last_comment_at": null
   },
   "gsd_route": null,
   "gsd_artifacts": { "type": null, "path": null },
@@ -238,7 +298,7 @@ with open('${MGW_DIR}/project.json', 'w') as f:
 "
 ```
 
-Valid stages: `new`, `triaged`, `planning`, `executing`, `verifying`, `pr-created`, `done`, `failed`.
+Valid stages: `new`, `triaged`, `planning`, `executing`, `verifying`, `pr-created`, `done`, `failed`, `blocked`.
 
 ### Advance Current Milestone
 Used after milestone completion to move pointer to next milestone.
@@ -262,6 +322,7 @@ Only advance if ALL issues in current milestone completed successfully.
 | validate_and_load | init.md, issue.md, run.md, update.md, link.md, pr.md, sync.md, milestone.md |
 | Per-issue staleness | run.md, issue.md, update.md |
 | Batch staleness | sync.md (full reconciliation), milestone.md |
+| Comment tracking | issue.md (populate), run.md (pre-flight check), sync.md (drift detection) |
 | Issue state schema | issue.md, run.md, update.md, sync.md |
 | Cross-refs schema | link.md, run.md, pr.md, sync.md |
 | Slug generation | issue.md, run.md |

--- a/.claude/commands/mgw/workflows/validation.md
+++ b/.claude/commands/mgw/workflows/validation.md
@@ -131,8 +131,9 @@ This rule applies to ALL MGW commands:
 
 | Command | Key Boundary Points |
 |---------|-------------------|
-| run.md | Spawns planner, executor, verifier — never reads code |
+| run.md | Spawns planner, executor, verifier, comment classifier — never reads code |
 | issue.md | Spawns analysis agent — never analyzes code itself |
+| review.md | Spawns comment classification agent — reads comments, not code |
 | pr.md | Spawns PR body builder — never reads code for description |
 | sync.md | Reads state + GitHub API only — never reads code |
 | update.md | Reads state only — posts comments |

--- a/commands/issue.md
+++ b/commands/issue.md
@@ -66,6 +66,27 @@ gh issue view $ISSUE_NUMBER --json number,title,body,labels,assignees,state,comm
 If issue not found → error: "Issue #$ISSUE_NUMBER not found in this repo."
 
 Store as $ISSUE_DATA.
+
+**Capture comment tracking snapshot:**
+
+Record the current comment count and timestamp of the most recent comment. These
+are stored in the triage state and used by run.md's pre-flight comment check to
+detect new comments posted between triage and execution.
+
+```bash
+COMMENT_COUNT=$(echo "$ISSUE_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('comments', [])))")
+LAST_COMMENT_AT=$(echo "$ISSUE_DATA" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+comments = d.get('comments', [])
+if comments:
+    print(comments[-1].get('createdAt', ''))
+else:
+    print('')
+" 2>/dev/null || echo "")
+```
+
+Store $COMMENT_COUNT and $LAST_COMMENT_AT for use in the write_state step.
 </step>
 
 <step name="assign_self">
@@ -223,6 +244,8 @@ Write to `.mgw/active/${ISSUE_NUMBER}-${slug}.json` using the schema from state.
 Populate:
 - issue: from $ISSUE_DATA
 - triage: from analysis report
+- triage.last_comment_count: from $COMMENT_COUNT (captured in fetch_issue step)
+- triage.last_comment_at: from $LAST_COMMENT_AT (captured in fetch_issue step, null if no comments)
 - gsd_route: confirmed or overridden route
 - pipeline_stage: "triaged"
 - All other fields: defaults (empty arrays, null)
@@ -257,11 +280,12 @@ Consider closing or commenting on the issue with your reasoning.
 
 <success_criteria>
 - [ ] Issue fetched from GitHub via gh CLI
+- [ ] Comment tracking snapshot captured (count + last timestamp)
 - [ ] Self-assigned if not already
 - [ ] Analysis agent spawned and returned structured report
 - [ ] Scope, validity, security, conflicts all assessed
 - [ ] GSD route recommended with reasoning
 - [ ] User confirms, overrides, or rejects
-- [ ] State file written to .mgw/active/ (if accepted)
+- [ ] State file written to .mgw/active/ (if accepted) with comment tracking fields
 - [ ] Next steps offered
 </success_criteria>

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,231 @@
+---
+name: mgw:review
+description: Review and classify new comments on a GitHub issue since last triage
+argument-hint: "<issue-number>"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Task
+  - AskUserQuestion
+---
+
+<objective>
+Standalone comment review for a triaged issue. Fetches new comments posted since
+triage, classifies them (material/informational/blocking), and updates the state
+file accordingly.
+
+Use this when you want to check for stakeholder feedback before running the pipeline,
+or to review comments on a blocked issue before unblocking it.
+</objective>
+
+<execution_context>
+@~/.claude/commands/mgw/workflows/state.md
+@~/.claude/commands/mgw/workflows/github.md
+@~/.claude/commands/mgw/workflows/gsd.md
+@~/.claude/commands/mgw/workflows/validation.md
+</execution_context>
+
+<context>
+Issue number: $ARGUMENTS
+
+State: .mgw/active/ (must exist — issue must be triaged first)
+</context>
+
+<process>
+
+<step name="validate_and_load">
+**Validate input and load state:**
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Parse $ARGUMENTS for issue number. If missing:
+```
+AskUserQuestion(
+  header: "Issue Number Required",
+  question: "Which issue number do you want to review comments for?",
+  followUp: "Enter the GitHub issue number (e.g., 42)"
+)
+```
+
+Load state file: `${REPO_ROOT}/.mgw/active/${ISSUE_NUMBER}-*.json`
+
+If no state file exists:
+```
+Issue #${ISSUE_NUMBER} hasn't been triaged yet.
+Run /mgw:issue ${ISSUE_NUMBER} first, then review comments.
+```
+</step>
+
+<step name="fetch_comments">
+**Fetch current comment state from GitHub:**
+
+```bash
+CURRENT_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"
+
+if [ -z "$STORED_COMMENTS" ] || [ "$STORED_COMMENTS" = "null" ]; then
+  STORED_COMMENTS=0
+fi
+
+NEW_COUNT=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+```
+
+If no new comments (`NEW_COUNT <= 0`):
+```
+No new comments on #${ISSUE_NUMBER} since triage (${STORED_COMMENTS} comments at triage, ${CURRENT_COMMENTS} now).
+```
+Stop.
+
+If new comments exist, fetch them:
+```bash
+NEW_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments \
+  --jq "[.comments[-${NEW_COUNT}:]] | .[] | {author: .author.login, body: .body, createdAt: .createdAt}" 2>/dev/null)
+```
+</step>
+
+<step name="classify_comments">
+**Spawn classification agent:**
+
+```
+Task(
+  prompt="
+<files_to_read>
+- ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
+</files_to_read>
+
+Classify new comments on GitHub issue #${ISSUE_NUMBER}.
+
+<issue_context>
+Title: ${issue_title}
+Current pipeline stage: ${pipeline_stage}
+GSD Route: ${gsd_route}
+Triage scope: ${triage.scope}
+</issue_context>
+
+<new_comments>
+${NEW_COMMENTS}
+</new_comments>
+
+<classification_rules>
+Classify each comment (and the overall batch) into ONE of:
+
+- **material** — Comment changes scope, requirements, acceptance criteria, or design.
+  Examples: 'Actually we also need to handle X', 'Changed the requirement to Y',
+  'Don't forget about edge case Z'.
+
+- **informational** — Status update, acknowledgment, question that doesn't change scope, +1.
+  Examples: 'Looks good', 'Thanks for picking this up', 'What's the ETA?', '+1'.
+
+- **blocking** — Explicit instruction to stop or wait. Must contain clear hold language.
+  Examples: 'Don't work on this yet', 'Hold off', 'Blocked by external dependency',
+  'Wait for design review'.
+
+If ANY comment in the batch is blocking, overall classification is blocking.
+If ANY comment is material (and none blocking), overall classification is material.
+Otherwise, informational.
+</classification_rules>
+
+<output_format>
+Return ONLY valid JSON:
+{
+  \"classification\": \"material|informational|blocking\",
+  \"reasoning\": \"Brief explanation of why this classification was chosen\",
+  \"per_comment\": [
+    {
+      \"author\": \"username\",
+      \"snippet\": \"first 100 chars of comment\",
+      \"classification\": \"material|informational|blocking\"
+    }
+  ],
+  \"new_requirements\": [\"list of new requirements if material, empty array otherwise\"],
+  \"blocking_reason\": \"reason if blocking, empty string otherwise\"
+}
+</output_format>
+",
+  subagent_type="general-purpose",
+  description="Classify comments on #${ISSUE_NUMBER}"
+)
+```
+</step>
+
+<step name="present_and_act">
+**Present classification and offer actions:**
+
+Display the classification result:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ MGW ► COMMENT REVIEW — #${ISSUE_NUMBER}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+New comments: ${NEW_COUNT} since triage
+Classification: ${classification}
+Reasoning: ${reasoning}
+
+${per_comment_table}
+
+${if material: 'New requirements detected:\n' + new_requirements}
+${if blocking: 'Blocking reason: ' + blocking_reason}
+```
+
+Offer actions based on classification:
+
+**If informational:**
+```
+AskUserQuestion(
+  header: "Informational Comments",
+  question: "Mark comments as reviewed and update state?",
+  options: [
+    { label: "Yes", description: "Update last_comment_count, continue" },
+    { label: "No", description: "Keep current state, don't update count" }
+  ]
+)
+```
+If yes: update `triage.last_comment_count` to $CURRENT_COMMENTS in state file.
+
+**If material:**
+```
+AskUserQuestion(
+  header: "Material Comments Detected",
+  question: "How should MGW handle the scope change?",
+  options: [
+    { label: "Acknowledge and continue", description: "Update state with new requirements, keep current route" },
+    { label: "Re-triage", description: "Run /mgw:issue to re-analyze with new context" },
+    { label: "Ignore", description: "Don't update state" }
+  ]
+)
+```
+If acknowledge: update `triage.last_comment_count` and store new_requirements in state.
+If re-triage: suggest running `/mgw:issue ${ISSUE_NUMBER}` to re-triage.
+
+**If blocking:**
+```
+AskUserQuestion(
+  header: "Blocking Comment Detected",
+  question: "Block the pipeline for this issue?",
+  options: [
+    { label: "Block", description: "Set pipeline_stage to 'blocked'" },
+    { label: "Override", description: "Ignore blocker, keep current stage" },
+    { label: "Review", description: "I'll review the comments manually" }
+  ]
+)
+```
+If block: update `pipeline_stage = "blocked"` and `triage.last_comment_count` in state.
+If override: update `triage.last_comment_count` only, keep pipeline_stage.
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Issue state loaded from .mgw/active/
+- [ ] Current comment count fetched from GitHub
+- [ ] New comments identified (delta from stored count)
+- [ ] Classification agent spawned and returned structured result
+- [ ] Classification presented to user with per-comment breakdown
+- [ ] User chose action (acknowledge/re-triage/block/ignore)
+- [ ] State file updated according to user choice
+</success_criteria>

--- a/commands/run.md
+++ b/commands/run.md
@@ -76,6 +76,7 @@ If no state file exists → issue not triaged yet. Run triage inline:
 If state file exists → load it. Check pipeline_stage:
   - "triaged" → proceed to GSD execution
   - "planning" / "executing" → resume from where we left off
+  - "blocked" → "Pipeline for #${ISSUE_NUMBER} is blocked by a stakeholder comment. Review the issue comments, resolve the blocker, then re-run."
   - "pr-created" / "done" → "Pipeline already completed for #${ISSUE_NUMBER}. Run /mgw:sync to reconcile."
 </step>
 
@@ -122,6 +123,99 @@ Add cross-ref (at `${REPO_ROOT}/.mgw/cross-refs.json`): issue → branch.
 - File operations, git commands, and agent work use **relative paths** (CWD = worktree)
 - `.mgw/` state operations use **absolute paths**: `${REPO_ROOT}/.mgw/`
   (`.mgw/` is gitignored — it only exists in the main repo, not the worktree)
+</step>
+
+<step name="preflight_comment_check">
+**Pre-flight comment check — detect new comments since triage:**
+
+Before GSD execution begins, check if new comments have been posted on the issue
+since triage. This prevents executing against a stale plan when stakeholders have
+posted material changes, blockers, or scope updates.
+
+```bash
+# Fetch current comment count from GitHub
+CURRENT_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"  # From state file
+
+# If stored count is missing (pre-comment-tracking state), skip check
+if [ -z "$STORED_COMMENTS" ] || [ "$STORED_COMMENTS" = "null" ] || [ "$STORED_COMMENTS" = "0" ]; then
+  STORED_COMMENTS=0
+fi
+```
+
+If new comments detected (`CURRENT_COMMENTS > STORED_COMMENTS`):
+
+1. **Fetch new comment bodies:**
+```bash
+NEW_COUNT=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+NEW_COMMENTS=$(gh issue view $ISSUE_NUMBER --json comments \
+  --jq "[.comments[-${NEW_COUNT}:]] | .[] | {author: .author.login, body: .body, createdAt: .createdAt}" 2>/dev/null)
+```
+
+2. **Spawn classification agent:**
+```
+Task(
+  prompt="
+<files_to_read>
+- ./CLAUDE.md (Project instructions — if exists, follow all guidelines)
+</files_to_read>
+
+Classify new comments on GitHub issue #${ISSUE_NUMBER}.
+
+<issue_context>
+Title: ${issue_title}
+Current pipeline stage: ${pipeline_stage}
+GSD Route: ${gsd_route}
+Triage scope: ${triage.scope}
+</issue_context>
+
+<new_comments>
+${NEW_COMMENTS}
+</new_comments>
+
+<classification_rules>
+Classify each comment (and the overall batch) into ONE of:
+
+- **material** — Comment changes scope, requirements, acceptance criteria, or design.
+  Examples: 'Actually we also need to handle X', 'Changed the requirement to Y',
+  'Don't forget about edge case Z'.
+
+- **informational** — Status update, acknowledgment, question that doesn't change scope, +1.
+  Examples: 'Looks good', 'Thanks for picking this up', 'What's the ETA?', '+1'.
+
+- **blocking** — Explicit instruction to stop or wait. Must contain clear hold language.
+  Examples: 'Don't work on this yet', 'Hold off', 'Blocked by external dependency',
+  'Wait for design review'.
+
+If ANY comment in the batch is blocking, overall classification is blocking.
+If ANY comment is material (and none blocking), overall classification is material.
+Otherwise, informational.
+</classification_rules>
+
+<output_format>
+Return ONLY valid JSON:
+{
+  \"classification\": \"material|informational|blocking\",
+  \"reasoning\": \"Brief explanation of why this classification was chosen\",
+  \"new_requirements\": [\"list of new requirements if material, empty array otherwise\"],
+  \"blocking_reason\": \"reason if blocking, empty string otherwise\"
+}
+</output_format>
+",
+  subagent_type="general-purpose",
+  description="Classify comments on #${ISSUE_NUMBER}"
+)
+```
+
+3. **React based on classification:**
+
+| Classification | Action |
+|---------------|--------|
+| **informational** | Log: "MGW: ${NEW_COUNT} new comment(s) reviewed — informational, continuing." Update `triage.last_comment_count` in state file. Continue pipeline. |
+| **material** | Log: "MGW: Material comment(s) detected — scope may have changed." Update state: add new_requirements to triage context. Update `triage.last_comment_count`. Re-read issue body for updated requirements. Continue with enriched context (pass new_requirements to planner). |
+| **blocking** | Log: "MGW: Blocking comment detected — pipeline paused." Update state: `pipeline_stage = "blocked"`. Post comment on issue: `> **MGW** . \`pipeline-blocked\` . Blocked by stakeholder comment. Reason: ${blocking_reason}`. Stop pipeline execution. |
+
+If no new comments detected, continue normally.
 </step>
 
 <step name="post_triage_update">
@@ -759,6 +853,7 @@ Next:
 <success_criteria>
 - [ ] Issue number validated and state loaded (or triage run first)
 - [ ] Isolated worktree created (.worktrees/ gitignored)
+- [ ] Pre-flight comment check performed (new comments classified before execution)
 - [ ] Structured triage comment posted on issue (scope, route, files, security)
 - [ ] GSD pipeline executed in worktree (quick or milestone route)
 - [ ] Execution-complete comment posted on issue (commits, changes, test status)

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -56,6 +56,15 @@ git ls-remote --heads origin ${BRANCH_NAME} | grep -q . && echo "remote" || echo
 
 # Worktree existence
 git worktree list | grep -q "${BRANCH_NAME}" && echo "worktree" || echo "no-worktree"
+
+# Comment delta (detect unreviewed comments since triage)
+CURRENT_COMMENTS=$(gh issue view ${NUMBER} --json comments --jq '.comments | length' 2>/dev/null || echo "0")
+STORED_COMMENTS="${triage.last_comment_count}"  # From state file, may be null/missing
+if [ -n "$STORED_COMMENTS" ] && [ "$STORED_COMMENTS" != "null" ]; then
+  COMMENT_DELTA=$(($CURRENT_COMMENTS - $STORED_COMMENTS))
+else
+  COMMENT_DELTA=0  # No baseline — skip comment drift
+fi
 ```
 
 Classify each issue into:
@@ -64,6 +73,7 @@ Classify each issue into:
 - **Orphaned:** Branch deleted but work incomplete
 - **Active:** Still in progress, everything consistent
 - **Drift:** State file says one thing, GitHub says another
+- **Unreviewed comments:** COMMENT_DELTA > 0 — new comments posted since triage that haven't been classified
 </step>
 
 <step name="health_check">
@@ -139,10 +149,12 @@ Active:    ${active_count} issues in progress
 Completed: ${completed_count} archived
 Stale:     ${stale_count} need attention
 Orphaned:  ${orphaned_count} need attention
+Comments:  ${comment_drift_count} issues with unreviewed comments
 Branches:  ${deleted_count} cleaned up
 ${HEALTH ? 'GSD Health: ' + HEALTH.status : ''}
 
 ${details_for_each_non_active_item}
+${comment_drift_details ? 'Unreviewed comments:\n' + comment_drift_details : ''}
 ```
 </step>
 
@@ -151,9 +163,10 @@ ${details_for_each_non_active_item}
 <success_criteria>
 - [ ] All .mgw/active/ files scanned
 - [ ] GitHub state checked for each issue, PR, branch
+- [ ] Comment delta checked for each active issue
 - [ ] Completed items moved to .mgw/completed/
 - [ ] Lingering worktrees cleaned up for completed items
 - [ ] Branch deletion offered for completed items
-- [ ] Stale/orphaned/drift items flagged
+- [ ] Stale/orphaned/drift items flagged (including comment drift)
 - [ ] Summary presented
 </success_criteria>


### PR DESCRIPTION
## Summary
- Add comment tracking to MGW pipeline so it detects new comments posted on issues between triage and execution
- Classify comments as material (scope change), informational (no impact), or blocking (halt pipeline) using a general-purpose agent
- Add pre-flight comment check in run.md that gates GSD execution on comment review
- Create standalone `/mgw:review` command for on-demand comment classification

Closes #36

## Milestone Context
- **Milestone:** v1 — Pipeline Intelligence
- **Phase:** 7 — Pipeline Fixes
- **Issue:** 2 of 4 in milestone

## Changes
- **State schema** (`workflows/state.md`): Added `triage.last_comment_count` and `triage.last_comment_at` fields to issue state schema; added `blocked` as valid pipeline stage; documented comment tracking lifecycle, classification rules, and drift detection
- **Pipeline orchestrator** (`commands/run.md`, `.claude/commands/mgw/run.md`): Added `preflight_comment_check` step between worktree creation and triage comment posting; spawns classification agent when new comments detected; handles material/informational/blocking responses
- **Triage** (`commands/issue.md`, `.claude/commands/mgw/issue.md`): Added comment snapshot capture in `fetch_issue` step; populates `last_comment_count` and `last_comment_at` in `write_state` step
- **Sync** (`commands/sync.md`, `.claude/commands/mgw/sync.md`): Added comment delta check in `check_each` step; reports unreviewed comments in sync summary
- **Review command** (`commands/review.md`, `.claude/commands/mgw/review.md`): New standalone command for on-demand comment review with interactive action selection
- **GitHub patterns** (`workflows/github.md`): Added comment count, recent comments, and last comment timestamp CLI patterns
- **GSD patterns** (`workflows/gsd.md`): Added comment classification agent spawn template
- **Validation** (`workflows/validation.md`): Added review.md to delegation boundary table

## Test Plan
- [ ] Verify `triage.last_comment_count` and `triage.last_comment_at` are populated when `/mgw:issue` runs triage on an issue with existing comments
- [ ] Verify `/mgw:run` pre-flight check correctly detects new comments when count exceeds stored value
- [ ] Verify pre-flight check skips gracefully when state file has no comment tracking fields (backward compatibility)
- [ ] Verify blocking classification sets `pipeline_stage` to `blocked` and halts execution
- [ ] Verify material classification enriches planner context with new requirements
- [ ] Verify informational classification logs and continues without blocking
- [ ] Verify `/mgw:sync` reports comment drift in sync summary
- [ ] Verify `/mgw:review` works standalone for manual comment triage
- [ ] Verify both `commands/` and `.claude/commands/mgw/` mirrors are in sync