### PR TITLE
feat: polish package.json metadata for npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,20 @@
     "type": "git",
     "url": "git+https://github.com/snipcodeit/mgw.git"
   },
-  "keywords": ["github", "cli", "automation", "pipeline", "gsd"],
+  "keywords": [
+    "claude-code",
+    "github",
+    "automation",
+    "project-management",
+    "gsd",
+    "cli",
+    "developer-tools",
+    "ai"
+  ],
   "author": "snipcodeit",
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/snipcodeit/mgw",
+  "bugs": {
+    "url": "https://github.com/snipcodeit/mgw/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- Expanded keywords array from 5 to 8 terms for improved npm discoverability (added `claude-code`, `project-management`, `developer-tools`, `ai`)
- Added `homepage` field pointing to the GitHub repository
- Added `bugs` field with the GitHub issues URL
- Verified existing fields (`repository`, `author`, `engines.node >= 18`, `bin`, `files`) are already correct

Closes #20

## Milestone Context
- **Milestone:** v1 — NPM Publishing & Distribution
- **Phase:** 3 — Package Preparation (issue 1/5 in milestone)

## Changes
- **package.json**: Added `homepage`, `bugs` fields; expanded `keywords` array with 8 npm-discoverability terms

## Test Plan
- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` shows 22 files, 58.6 kB — no extraneous files
- [x] `bin.mgw` resolves to `./dist/bin/mgw.cjs` (exists after build)
- [x] `files` array covers `dist/`, `commands/`, `templates/` (all distributable content)
- [x] `engines.node` is `>=18.0.0`
- [x] `repository` URL is `git+https://github.com/snipcodeit/mgw.git`