### PR TITLE
Add link references to extended docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MGW is a [Claude Code slash command](https://docs.anthropic.com/en/docs/claude-c
   Merge → issue auto-closes
 ```
 
-Each step is composable. Use the full pipeline or pick individual commands.
+Each step is composable. Use the full pipeline or pick individual commands. For a detailed breakdown of the pipeline stages and agent delegation model, see the [Architecture Guide](docs/ARCHITECTURE.md).
 
 ## Why I Built This
 
@@ -60,6 +60,8 @@ So I built MGW to be the responsible adult in the room. I point it at an issue, 
 | `/mgw:sync` | Reconcile local state with GitHub |
 | `/mgw:help` | Command reference |
 
+For detailed usage of every command including flags, examples, and edge cases, see the [User Guide](docs/USER-GUIDE.md#command-reference).
+
 ## How Triage Works
 
 `/mgw:issue` spawns an analysis agent that reads your codebase and evaluates the issue across five dimensions:
@@ -77,6 +79,8 @@ Based on scope, MGW recommends a GSD route:
 | Small (1-2 files) | `gsd:quick` | Single-pass plan + execute |
 | Medium (3-8 files) | `gsd:quick --full` | Plan with verification loop |
 | Large (9+ files) | `gsd:new-milestone` | Full milestone with phased execution |
+
+For a deeper explanation of how GSD routes work, including dependency ordering and how MGW selects the right route, see the [User Guide](docs/USER-GUIDE.md#gsd-routes-explained).
 
 ## Status Comments
 
@@ -105,7 +109,7 @@ Every pipeline step posts a structured comment on the issue so you (and your tea
 </details>
 ```
 
-Comments are posted for: `work-started`, `triage-complete`, `execution-complete`, `pr-ready`, and `pipeline-failed`. The milestone orchestrator handles all comment posting directly (not delegated to sub-agents), guaranteeing every stage is logged.
+Comments are posted for: `work-started`, `triage-complete`, `execution-complete`, `pr-ready`, and `pipeline-failed`. The milestone orchestrator handles all comment posting directly (not delegated to sub-agents), guaranteeing every stage is logged. For the full list of comment formats and customization options, see the [User Guide](docs/USER-GUIDE.md#status-comments-and-pr-descriptions).
 
 ## PR Descriptions
 
@@ -145,7 +149,7 @@ MGW tracks pipeline state in a local `.mgw/` directory (gitignored, per-develope
 
 Pipeline stages flow: `new` → `triaged` → `planning` → `executing` → `verifying` → `pr-created` → `done` (or `failed`)
 
-The `/mgw:sync` command reconciles local state with GitHub reality — archiving completed work, flagging stale branches, and catching drift.
+The `/mgw:sync` command reconciles local state with GitHub reality — archiving completed work, flagging stale branches, and catching drift. For the complete state schema and configuration reference, see the [User Guide](docs/USER-GUIDE.md#the-mgw-directory). For how state flows through the system, see the [Architecture Guide](docs/ARCHITECTURE.md#state-management).
 
 ## Requirements
 
@@ -239,6 +243,8 @@ Then in Claude Code:
 /mgw:sync                              # Clean up stale state
 ```
 
+For step-by-step walkthroughs of common scenarios including failure recovery, see the [User Guide](docs/USER-GUIDE.md#workflow-walkthrough).
+
 ## Project Structure
 
 ```
@@ -278,6 +284,15 @@ templates/
         gsd.md             GSD agent spawn templates
         validation.md      Delegation boundary rules
 ```
+
+For a detailed walkthrough of the directory structure, slash command anatomy, and CLI architecture, see the [Architecture Guide](docs/ARCHITECTURE.md#directory-structure).
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture Guide](docs/ARCHITECTURE.md) | System design: the two-layer model (MGW orchestrates, GSD executes), delegation boundary, pipeline data flow, state schema, agent model, and slash command anatomy |
+| [User Guide](docs/USER-GUIDE.md) | Practical usage: configuration reference, full command reference with examples, workflow walkthroughs, GSD route explanations, dependency ordering, failure recovery, and FAQ |
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Add inline cross-reference links throughout README.md pointing to docs/ARCHITECTURE.md and docs/USER-GUIDE.md for deeper coverage of specific topics
- Add a dedicated Documentation section listing all extended docs with descriptions for easy discoverability
- Links reference expected paths (docs/ARCHITECTURE.md, docs/USER-GUIDE.md) that will resolve once PRs #48 and #49 are merged

Closes #28

## Milestone Context
- **Milestone:** v1 — Documentation & Developer Experience
- **Phase:** 6 — README Final Polish
- **Issue:** 4 of 4 in milestone

## Changes
- **README.md**
  - Added Architecture Guide link after What It Does section (pipeline stages and agent delegation)
  - Added User Guide link after Commands table (full command reference with flags and examples)
  - Added User Guide link after How Triage Works section (GSD routes explanation)
  - Added User Guide link after Status Comments section (comment formats and customization)
  - Added Architecture Guide and User Guide links after State Management section (state schema and configuration)
  - Added User Guide link after Typical Workflow section (workflow walkthroughs and failure recovery)
  - Added Architecture Guide link after Project Structure section (directory structure and CLI architecture)
  - Added new Documentation section with table listing both extended docs and their descriptions

## Test Plan
- [ ] Verify README renders correctly on GitHub with all new links visible
- [ ] Confirm link text is descriptive and contextually appropriate for each section
- [ ] Verify link paths match expected file locations (docs/ARCHITECTURE.md, docs/USER-GUIDE.md)
- [ ] Verify anchor fragment links match actual heading slugs in the extended docs (#command-reference, #gsd-routes-explained, #status-comments-and-pr-descriptions, #the-mgw-directory, #state-management, #workflow-walkthrough, #directory-structure)
- [ ] Confirm no existing content was modified beyond adding cross-reference sentences
- [ ] Links will resolve after PRs #48 and #49 are merged