### PR TITLE
docs: create GitHub Wiki for MGW documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ For a detailed walkthrough of the directory structure, slash command anatomy, an
 
 | Document | Description |
 |----------|-------------|
+| [Wiki](https://github.com/snipcodeit/mgw/wiki) | Comprehensive documentation hub: getting started, commands reference, workflow guide, architecture, configuration, troubleshooting |
 | [Architecture Guide](docs/ARCHITECTURE.md) | System design: the two-layer model (MGW orchestrates, GSD executes), delegation boundary, pipeline data flow, state schema, agent model, and slash command anatomy |
 | [User Guide](docs/USER-GUIDE.md) | Practical usage: configuration reference, full command reference with examples, workflow walkthroughs, GSD route explanations, dependency ordering, failure recovery, and FAQ |
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,434 @@
+# Architecture
+
+This page describes the internal architecture of MGW: how it is structured, why it is structured that way, and how the pieces fit together.
+
+---
+
+## System Overview
+
+MGW (My GSD Workflow) is a GitHub-native issue-to-PR automation system for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview). It takes a GitHub issue, triages it, plans the work, executes it through [Get Shit Done](https://github.com/glittercowboy/get-shit-done) (GSD), and opens a pull request -- posting structured status comments at every stage.
+
+MGW exists at a specific layer in the development stack:
+
+```
+GitHub (issues, PRs, milestones, labels)
+    ^
+    |  reads/writes metadata
+    |
+MGW (orchestration layer)
+    |
+    |  spawns agents, passes context
+    v
+GSD (execution layer -- planning, coding, verification)
+    |
+    |  reads/writes application code
+    v
+Your Codebase
+```
+
+MGW never touches application code. It reads GitHub state, manages pipeline state, and delegates all code-touching work to GSD agents. This separation is the core architectural principle.
+
+---
+
+## The Two-Layer Model
+
+MGW and GSD serve distinct, complementary roles.
+
+### MGW: The Orchestration Layer
+
+MGW owns the GitHub lifecycle:
+
+- **Issue triage** -- spawn analysis agents, store results, post structured comments
+- **Pipeline sequencing** -- move issues through stages (new, triaged, planning, executing, verifying, pr-created, done)
+- **State management** -- read/write `.mgw/` state files, track cross-references
+- **GitHub communication** -- post status comments, create PRs, manage labels and milestones
+- **Agent spawning** -- invoke Claude Code `Task()` agents with the right context
+- **Worktree management** -- create isolated git worktrees, clean up after PR creation
+
+### GSD: The Execution Layer
+
+GSD owns planning, coding, and verification:
+
+- **Planning** -- create PLAN.md files with tasks, files, and verification steps
+- **Code execution** -- read application code, write application code, make implementation decisions
+- **Verification** -- check that plans were executed correctly, run tests, validate artifacts
+- **State tracking** -- manage `.planning/` directories with ROADMAP.md, STATE.md, config.json
+
+### What Each Layer Owns
+
+```
+MGW Owns                          GSD Owns
+------                            --------
+.mgw/                             .planning/
+  project.json                      config.json
+  active/*.json                     ROADMAP.md
+  completed/                        STATE.md
+  cross-refs.json                   quick/
+  config.json                         *-PLAN.md
+                                      *-SUMMARY.md
+GitHub metadata                       *-VERIFICATION.md
+  Issues, PRs, milestones
+  Labels, comments                Application code
+  Branches (creation/push)          Source files
+                                    Tests
+Pipeline stage transitions          Architecture decisions
+Agent invocation
+Worktree lifecycle
+```
+
+MGW never writes to `.planning/` state files. GSD never writes to `.mgw/`. The only shared surface is the GSD artifacts directory (PLAN.md, SUMMARY.md, VERIFICATION.md), which GSD writes and MGW reads.
+
+---
+
+## The Delegation Boundary
+
+The delegation boundary is the architectural rule that keeps MGW and GSD separate. It has a mechanical check:
+
+> **For any logic in an MGW command, ask: "If GSD improved this tomorrow, would MGW automatically benefit?"**
+
+- **YES** -- the logic is correctly delegated
+- **NO** -- the logic is misplaced in MGW
+
+### What MGW May Do Directly
+
+```
+- Read/write .mgw/ state files (JSON)
+- Read/write GitHub metadata (via gh CLI)
+- Parse command arguments
+- Display user-facing output
+- Spawn Task() agents
+- Call gsd-tools.cjs for utilities
+- Manage git worktrees and branches
+```
+
+### What MGW Must Never Do
+
+```
+- Read application source code
+- Write application source code
+- Analyze code for scope, security, or conflicts
+- Make architecture or implementation decisions
+- Generate PR descriptions from code analysis (only from GSD artifacts)
+- Run or interpret application tests
+```
+
+---
+
+## Pipeline Data Flow
+
+### How an Issue Becomes a PR
+
+End-to-end data flow for `/mgw:run`:
+
+```
+GitHub Issue #42
+    |
+    v
+[1] VALIDATE & LOAD
+    Parse issue number, check .mgw/active/ for existing state
+    |
+    v
+[2] CREATE WORKTREE
+    Derive branch: issue/42-fix-auth
+    git worktree add .worktrees/issue/42-fix-auth
+    |
+    v
+[3] PRE-FLIGHT COMMENT CHECK
+    Compare comment count with triage snapshot
+    Classify new comments: material / informational / blocking
+    |
+    v
+[4] POST TRIAGE COMMENT
+    Structured comment: scope, route, files, security
+    |
+    v
+[5] EXECUTE GSD
+    Quick route: init -> plan -> execute -> verify
+    Milestone route: init -> roadmap -> (plan -> execute -> verify) per phase
+    |
+    v
+[6] POST EXECUTION COMMENT
+    Commit count, file changes, test status
+    |
+    v
+[7] CREATE PR
+    Push branch, read GSD artifacts, generate PR body
+    |
+    v
+[8] CLEANUP
+    Remove worktree, post pr-ready comment, update state
+    |
+    v
+PR #85 ready for review
+Issue #42 auto-closes on merge
+```
+
+---
+
+## State Management
+
+### The `.mgw/` Directory
+
+```
+.mgw/
+  project.json          Milestones, issues, phases, dependency graph
+  config.json           User prefs (GitHub username, default filters)
+  active/               In-progress issue pipelines
+    42-fix-auth.json    Per-issue state
+  completed/            Archived after PR merge
+  cross-refs.json       Bidirectional issue/PR/branch links
+```
+
+See [[Configuration]] for full details on each file.
+
+### Pipeline Stages
+
+```
+new --> triaged --> planning --> executing --> verifying --> pr-created --> done
+                                                                    \
+                                                                     --> failed
+                                                                     --> blocked
+```
+
+| Stage | Set By | Meaning |
+|-------|--------|---------|
+| `new` | `/mgw:project` or manual | Issue exists but has not been analyzed |
+| `triaged` | `/mgw:issue` | Triage complete: scope, route, security assessed |
+| `planning` | `/mgw:run` | GSD planner agent is creating PLAN.md |
+| `executing` | `/mgw:run` | GSD executor agent is writing code |
+| `verifying` | `/mgw:run` | GSD verifier agent is checking results |
+| `pr-created` | `/mgw:run` | PR has been opened on GitHub |
+| `done` | `/mgw:run` or `/mgw:sync` | PR merged, issue closed, state archived |
+| `failed` | `/mgw:run` or `/mgw:milestone` | Pipeline failed, no PR created |
+| `blocked` | `/mgw:run` | Blocking comment detected, pipeline paused |
+
+### Staleness Detection
+
+MGW runs lightweight staleness checks on every command that touches state:
+
+- **Per-issue**: compares GitHub `updatedAt` timestamp with local state file modification time
+- **Batch (milestone-level)**: single GraphQL call to check all open issues at once
+
+If stale state is detected, MGW auto-syncs with a notice. If the check fails (network error, API limit), MGW continues silently.
+
+---
+
+## Agent Delegation Model
+
+MGW delegates all code-touching work to Claude Code `Task()` agents:
+
+| Agent Type | Purpose | Spawned By |
+|-----------|---------|------------|
+| `general-purpose` | Triage, comment classification, PR body, question routing | `/mgw:issue`, `/mgw:run`, `/mgw:pr`, `/mgw:ask`, `/mgw:review` |
+| `gsd-planner` | Create PLAN.md from issue description and triage context | `/mgw:run` |
+| `gsd-executor` | Execute plan tasks: read code, write code, commit | `/mgw:run` |
+| `gsd-verifier` | Verify execution against plan goals | `/mgw:run` |
+| `gsd-plan-checker` | Review plan structure and coverage (quick --full) | `/mgw:run` |
+
+### Mandatory Context Injection
+
+Every `Task()` spawn includes project context at the start of its prompt:
+
+```markdown
+<files_to_read>
+- ./CLAUDE.md (Project instructions)
+- .agents/skills/ (Project skills)
+</files_to_read>
+```
+
+This ensures agents inherit project-specific conventions, security requirements, and coding standards.
+
+### Model Resolution
+
+Agent models are resolved at runtime through GSD tools:
+
+```bash
+PLANNER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-planner --raw)
+EXECUTOR_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-executor --raw)
+```
+
+---
+
+## Slash Command Anatomy
+
+Slash commands are plain Markdown files with YAML frontmatter:
+
+```markdown
+---
+name: mgw:command-name
+description: One-line description for Claude Code's autocomplete
+argument-hint: "<required-arg> [optional-arg]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Task
+---
+
+<objective>
+What this command does and when to use it.
+</objective>
+
+<execution_context>
+@~/.claude/commands/mgw/workflows/state.md
+@~/.claude/commands/mgw/workflows/github.md
+@~/.claude/commands/mgw/workflows/gsd.md
+@~/.claude/commands/mgw/workflows/validation.md
+</execution_context>
+
+<context>
+Runtime data: $ARGUMENTS, state files, etc.
+</context>
+
+<process>
+<step name="step_name">
+Step-by-step instructions for Claude to follow.
+</step>
+</process>
+
+<success_criteria>
+Checklist of conditions that must be true when the command completes.
+</success_criteria>
+```
+
+### Command Deployment
+
+Commands live in two locations:
+
+- **Source**: `commands/` in the repo (canonical, version-controlled)
+- **Deployed**: `~/.claude/commands/mgw/` (where Claude Code reads them)
+
+---
+
+## CLI Architecture
+
+The `mgw` CLI (`bin/mgw.cjs`) is a thin Node.js wrapper built with [Commander.js](https://github.com/tj/commander.js).
+
+### How the CLI Invokes Claude
+
+```
+mgw run 42
+    |
+    v
+bin/mgw.cjs (Commander.js)
+    |
+    |  1. assertClaudeAvailable()
+    |  2. Resolves command file: commands/run.md
+    |
+    v
+claude -p --system-prompt-file commands/run.md "42"
+    |
+    |  Claude reads Markdown as system prompt
+    |  Claude executes the <process> steps
+    |
+    v
+Output streamed to terminal
+```
+
+### Library Modules
+
+```
+lib/
+  index.cjs             Barrel export
+  claude.cjs            Claude CLI detection and invocation
+  github.cjs            GitHub API via gh CLI wrappers
+  gsd.cjs               GSD tools bridge
+  state.cjs             .mgw/ state management
+  output.cjs            Terminal output utilities
+  templates.cjs         Template system re-export
+  template-loader.cjs   JSON Schema validation
+```
+
+---
+
+## Shared Workflow System
+
+Slash commands include shared logic from `.claude/commands/mgw/workflows/` via `@`-include directives:
+
+| File | What It Provides |
+|------|-----------------|
+| `state.md` | Entry point, `.mgw/` schema, staleness detection, comment tracking, slug generation |
+| `github.md` | `gh` CLI snippets for every GitHub operation MGW performs |
+| `gsd.md` | `Task()` spawn templates, model resolution, pipeline patterns |
+| `validation.md` | Delegation boundary rule, mechanical check, review checklist |
+
+---
+
+## GSD Artifact Flow into PRs
+
+When GSD agents execute, they produce artifacts that MGW reads for PR descriptions:
+
+```
+GSD Planner --> .planning/quick/3-fix-auth/3-PLAN.md
+    |
+GSD Executor --> .planning/quick/3-fix-auth/3-SUMMARY.md
+    |
+GSD Verifier --> .planning/quick/3-fix-auth/3-VERIFICATION.md
+    |
+MGW PR Agent reads all three artifacts
+    |
+    v
+PR Body:
+    ## Summary         <-- from SUMMARY.md
+    Closes #42
+    ## Milestone Context <-- from .mgw/project.json
+    ## Changes         <-- from SUMMARY.md key_files
+    ## Test Plan       <-- from VERIFICATION.md
+```
+
+The PR agent is a `general-purpose` type (no code execution). It reads artifacts as text and composes the PR body. It never reads application source code.
+
+---
+
+## Directory Structure
+
+```
+mgw/
+  bin/
+    mgw.cjs                   CLI entry point (Commander.js)
+  lib/
+    index.cjs                 Barrel export
+    claude.cjs                Claude CLI detection and invocation
+    github.cjs                GitHub API via gh CLI wrappers
+    gsd.cjs                   GSD tools bridge
+    state.cjs                 .mgw/ state management
+    output.cjs                Terminal output utilities
+    templates.cjs             Template system re-export
+    template-loader.cjs       JSON Schema validation
+  commands/                   Slash command source files
+    ask.md                    Question routing during milestone execution
+    help.md                   Command reference display
+    init.md                   One-time repo bootstrap
+    issue.md                  Deep triage with agent analysis
+    issues.md                 Issue browser with filters
+    link.md                   Cross-referencing system
+    milestone.md              Milestone execution with dependency ordering
+    next.md                   Next unblocked issue picker
+    pr.md                     PR creation from GSD artifacts
+    project.md                AI-driven project scaffolding
+    review.md                 Comment classification
+    run.md                    Autonomous pipeline orchestrator
+    status.md                 Project status dashboard
+    sync.md                   State reconciliation
+    update.md                 Structured GitHub comment templates
+  .claude/commands/mgw/       Deployed slash commands
+    workflows/
+      state.md                Shared state schema
+      github.md               Shared GitHub CLI patterns
+      gsd.md                  GSD agent spawn templates
+      validation.md           Delegation boundary rules
+  templates/
+    schema.json               JSON Schema for /mgw:project output
+  docs/
+    ARCHITECTURE.md           Detailed architecture document
+    USER-GUIDE.md             Comprehensive user guide
+```
+
+---
+
+## Next Steps
+
+- [[Commands Reference]] -- What every command does
+- [[Configuration]] -- State files, schemas, and settings
+- [[Workflow Guide]] -- Practical usage patterns

--- a/wiki/Commands-Reference.md
+++ b/wiki/Commands-Reference.md
@@ -1,0 +1,381 @@
+# Commands Reference
+
+Complete reference for all MGW commands. Each command is available as both a Claude Code slash command (`/mgw:command`) and a CLI command (`mgw command`).
+
+---
+
+## Command Overview
+
+| Command | Description | Requires Claude? |
+|---------|-------------|:---:|
+| `/mgw:init` | Bootstrap repo for MGW | Yes |
+| `/mgw:project` | Scaffold milestones and issues from description | Yes |
+| `/mgw:issues` | Browse and filter GitHub issues | No |
+| `/mgw:issue <n>` | Deep triage of a single issue | Yes |
+| `/mgw:next` | Show next unblocked issue | Yes |
+| `/mgw:run <n>` | Full autonomous pipeline: triage through PR | Yes |
+| `/mgw:milestone [n]` | Execute a milestone's issues in dependency order | Yes |
+| `/mgw:update <n>` | Post structured status comment | Yes |
+| `/mgw:pr [n]` | Create PR from GSD artifacts | Yes |
+| `/mgw:link <ref> <ref>` | Cross-reference issues, PRs, branches | No |
+| `/mgw:status [n]` | Project dashboard | No |
+| `/mgw:sync` | Reconcile local state with GitHub | No |
+| `/mgw:ask <question>` | Route a question during work | Yes |
+| `/mgw:review <n>` | Classify new comments on an issue | Yes |
+| `/mgw:help` | Command reference display | No |
+
+---
+
+## Setup Commands
+
+### `/mgw:init`
+
+Bootstrap a repository for MGW. One-time setup, safe to re-run.
+
+**Usage:**
+```
+/mgw:init
+```
+
+**What it creates:**
+- `.mgw/` state directory (gitignored)
+- `.mgw/cross-refs.json` for tracking links
+- GitHub issue templates (bug report + enhancement)
+- GitHub PR template
+- Standard labels on the repository
+- `.gitignore` entries for `.mgw/` and `.worktrees/`
+
+**Notes:**
+- Safe to re-run -- skips anything that already exists
+- Does not require an existing `.mgw/` directory
+- Does not touch any existing files
+
+---
+
+### `/mgw:project`
+
+Scaffold an entire project from a description. Creates milestones, issues, dependency labels, and project state.
+
+**Usage:**
+```
+/mgw:project
+```
+
+**What it does:**
+1. Asks "What are you building?"
+2. Generates project-specific milestones, phases, and issues using AI
+3. Creates GitHub milestones with descriptions
+4. Creates issues assigned to milestones with phase labels
+5. Adds `blocked-by:#N` labels for dependency tracking
+6. Writes `.mgw/project.json` with full project state
+
+**Important:**
+- Creates structure only -- does **not** trigger execution
+- Run `/mgw:milestone` to begin working through issues
+- Does not ask you to pick a template type -- the AI infers project structure from your description
+
+---
+
+## Browse and Triage Commands
+
+### `/mgw:issues [filters]`
+
+List open issues with optional filters. Works without Claude.
+
+**Usage:**
+```
+/mgw:issues                        # Your open issues (default: @me, open)
+/mgw:issues --label bug            # Filter by label
+/mgw:issues --milestone "v2.0"     # Filter by milestone
+/mgw:issues --assignee all         # All open issues (not just yours)
+/mgw:issues --state closed         # Closed issues
+/mgw:issues --json                 # JSON output for scripting
+```
+
+**CLI equivalent:**
+```bash
+mgw issues
+mgw issues --label bug --json
+```
+
+---
+
+### `/mgw:issue <number>`
+
+Deep triage of a single issue against the codebase. Spawns an analysis agent that evaluates five dimensions.
+
+**Usage:**
+```
+/mgw:issue 42
+```
+
+**Triage dimensions:**
+- **Scope** -- Which files and systems are affected, estimated size
+- **Validity** -- Can the issue be confirmed by reading the code?
+- **Purpose** -- Who benefits, what is the impact of inaction?
+- **Security** -- Does it touch auth, user data, external APIs?
+- **Conflicts** -- Does it overlap with other in-progress work?
+
+**Output:**
+- A recommended GSD route (`quick`, `quick --full`, or `new-milestone`)
+- A state file at `.mgw/active/<number>-<slug>.json`
+- A triage comment posted on the GitHub issue
+
+---
+
+### `/mgw:next`
+
+Show the next unblocked issue based on dependency order. Read-only -- does not start any work.
+
+**Usage:**
+```
+/mgw:next
+```
+
+**Displays:**
+- Recommended issue with full context (GSD route, phase, labels)
+- Resolved dependencies (what had to finish first)
+- What this issue unblocks (downstream issues)
+- Alternative unblocked issues (if multiple are available)
+- Offer to start `/mgw:run` for the recommended issue
+
+---
+
+## Pipeline Commands
+
+### `/mgw:run <number>`
+
+The main command. Runs the full autonomous pipeline for a single issue.
+
+**Usage:**
+```
+/mgw:run 42
+```
+
+**Pipeline stages:**
+1. **Validate** -- Load or create triage state
+2. **Worktree** -- Create isolated git worktree (`issue/42-<slug>`)
+3. **Pre-flight** -- Check for new comments since triage (classify as material/informational/blocking)
+4. **Triage comment** -- Post structured triage results on the issue
+5. **GSD execution** -- Run the appropriate GSD route
+6. **Execution comment** -- Post commit count, file changes, test status
+7. **PR creation** -- Push branch, create PR with milestone context
+8. **PR-ready comment** -- Post PR link and pipeline summary
+9. **Cleanup** -- Remove worktree, update state
+
+**Notes:**
+- If the issue has not been triaged yet, `/mgw:run` runs triage inline first
+- All work happens in an isolated worktree -- your main workspace stays clean
+- Posts structured status comments at every stage
+
+**CLI equivalent:**
+```bash
+mgw run 42
+mgw run 42 --dry-run    # Preview without executing
+mgw run 42 --quiet      # Buffer output, show summary at end
+```
+
+---
+
+### `/mgw:milestone [number] [--interactive] [--dry-run]`
+
+Execute all issues in a milestone in dependency order. The most powerful command -- it chains multiple `/mgw:run` invocations with checkpointing.
+
+**Usage:**
+```
+/mgw:milestone              # Current milestone (from project.json)
+/mgw:milestone 2            # Specific milestone by number
+/mgw:milestone --dry-run    # Show execution plan without running
+/mgw:milestone --interactive  # Pause between issues for review
+```
+
+**What it does:**
+1. Loads `project.json` and resolves the target milestone
+2. Runs a batch staleness check against GitHub
+3. Checks API rate limits (caps execution if limits are low)
+4. Topologically sorts issues by dependency (Kahn's algorithm)
+5. Filters out already-completed issues
+6. For each issue: posts work-started comment, runs pipeline, posts result comment
+7. Handles failures: marks failed issues, blocks dependents, continues with unblocked issues
+8. On full completion: closes GitHub milestone, creates draft release, advances to next milestone
+
+**Flags:**
+- `--dry-run` -- Show execution order table with dependencies and rate limit estimates. Does not execute.
+- `--interactive` -- Pause after each issue with options: Continue, Skip next, Abort.
+
+**CLI equivalent:**
+```bash
+mgw milestone
+mgw milestone 2 --interactive
+mgw milestone --dry-run
+```
+
+---
+
+## Query Commands
+
+### `/mgw:status [milestone] [--json]`
+
+Project dashboard showing milestone progress, issue pipeline stages, and open PRs.
+
+**Usage:**
+```
+/mgw:status              # Current milestone
+/mgw:status 2            # Specific milestone
+/mgw:status --json       # Machine-readable output
+```
+
+**Displays:**
+- Progress bar with percentage
+- Per-issue pipeline stages with icons
+- Open PRs matched to milestone issues
+- Next milestone preview
+
+Falls back gracefully when no `project.json` exists (shows GitHub-only status with open issues and PRs).
+
+---
+
+### `/mgw:ask <question>`
+
+Route a question or observation during work. Classifies it against the current project context.
+
+**Usage:**
+```
+/mgw:ask "The slug generation doesn't handle unicode characters"
+```
+
+**Classifications:**
+- **In-scope** -- Relates to the current active issue. Include in current work.
+- **Adjacent** -- Relates to a different issue in the same milestone. Suggest posting a comment.
+- **Separate** -- No matching issue. Suggest filing a new one.
+- **Duplicate** -- Matches an existing issue. Point to it.
+- **Out-of-scope** -- Beyond the current milestone. Note for future planning.
+
+---
+
+### `/mgw:review <number>`
+
+Review and classify new comments on a GitHub issue since last triage.
+
+**Usage:**
+```
+/mgw:review 42
+```
+
+**What it does:**
+- Fetches new comments posted since triage
+- Classifies each as **material** (changes scope), **informational** (status update), or **blocking** (explicit "stop")
+- Updates the state file accordingly
+
+Use this when you want to check for stakeholder feedback before running the pipeline, or to review comments on a blocked issue before unblocking it.
+
+---
+
+## GitHub Operations
+
+### `/mgw:update <number> [message]`
+
+Post a structured status comment on an issue.
+
+**Usage:**
+```
+/mgw:update 42                           # Auto-detect status from state
+/mgw:update 42 "switching approach"      # Custom message
+```
+
+---
+
+### `/mgw:pr [number] [--base branch]`
+
+Create a PR from GSD artifacts.
+
+**Usage:**
+```
+/mgw:pr                    # From current branch
+/mgw:pr 42                 # Linked to issue #42
+/mgw:pr 42 --base develop  # Custom base branch
+```
+
+**PR body includes:**
+- Summary from GSD execution artifacts
+- Milestone context (milestone name, phase, position in sequence)
+- File-level changes grouped by module
+- Testing procedures from verification artifacts
+- Cross-references from `.mgw/cross-refs.json`
+
+---
+
+### `/mgw:link <ref> <ref>`
+
+Create a bidirectional cross-reference between issues, PRs, and branches.
+
+**Usage:**
+```
+/mgw:link 42 #43              # Issue-to-issue
+/mgw:link 42 branch:fix/auth  # Issue-to-branch
+```
+
+Posts GitHub comments on both referenced issues (unless `--quiet`). Records the link in `.mgw/cross-refs.json`.
+
+**CLI equivalent:**
+```bash
+mgw link 42 43
+mgw link 42 43 --quiet    # Skip GitHub comments
+mgw link 42 43 --dry-run  # Preview without creating
+mgw link 42 43 --json     # JSON output
+```
+
+---
+
+## Maintenance Commands
+
+### `/mgw:sync`
+
+Reconcile local `.mgw/` state with GitHub reality.
+
+**Usage:**
+```
+/mgw:sync
+mgw sync                # CLI equivalent
+mgw sync --dry-run      # Preview what would change
+mgw sync --json         # JSON output
+```
+
+**What it does:**
+- Compares local issue state with GitHub issue state
+- Archives completed issues (moves from `active/` to `completed/`)
+- Flags stale branches and drift
+
+---
+
+### `/mgw:help`
+
+Display the command reference. No side effects, works without Claude.
+
+**Usage:**
+```
+/mgw:help
+mgw help     # CLI equivalent
+```
+
+---
+
+## Global CLI Flags
+
+Every CLI subcommand supports these flags:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would happen without executing |
+| `--json` | Output structured JSON instead of formatted text |
+| `-v, --verbose` | Show API calls and file writes |
+| `--debug` | Full payloads, timings, and internal state |
+| `--model <model>` | Override the Claude model for AI-dependent commands |
+
+---
+
+## Next Steps
+
+- [[Workflow Guide]] -- End-to-end walkthroughs
+- [[Architecture]] -- How the pipeline works internally
+- [[Configuration]] -- Customize state, templates, and environment

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,293 @@
+# Configuration
+
+MGW stores all pipeline state locally in the `.mgw/` directory at your repository root. This page covers every file in that directory, the full state schema, environment variables, and template customization.
+
+---
+
+## The `.mgw/` Directory
+
+```
+.mgw/
+  config.json          User preferences
+  project.json         Project structure: milestones, phases, issues
+  active/              In-progress issue pipelines
+    42-fix-auth.json   Per-issue state
+  completed/           Archived state files (moved here after PR merge)
+  cross-refs.json      Bidirectional links: issue <-> PR <-> branch
+```
+
+The `.mgw/` directory is:
+- **Local-only** -- gitignored, per-developer
+- **Safe to delete** -- run `/mgw:init` to recreate the structure; nothing on GitHub is affected
+- **Created by** `/mgw:init`
+
+---
+
+## config.json
+
+User-level preferences:
+
+```json
+{
+  "github_username": "your-username",
+  "default_assignee": "@me",
+  "default_state": "open"
+}
+```
+
+This file is optional. MGW falls back to sensible defaults when it is absent.
+
+---
+
+## project.json
+
+Created by `/mgw:project`. Contains the full project structure:
+
+```json
+{
+  "project": {
+    "name": "my-app",
+    "description": "A web application for ...",
+    "repo": "owner/my-app",
+    "template": "web-app",
+    "created": "2026-02-26T10:00:00Z",
+    "project_board": {
+      "number": 1,
+      "url": "https://github.com/orgs/owner/projects/1"
+    }
+  },
+  "milestones": [
+    {
+      "github_number": 1,
+      "github_id": 12345,
+      "name": "v1 -- Core Features",
+      "issues": [
+        {
+          "github_number": 10,
+          "title": "Design database schema",
+          "phase_number": 1,
+          "phase_name": "Database Layer",
+          "gsd_route": "quick",
+          "labels": ["backend", "database"],
+          "depends_on_slugs": [],
+          "pipeline_stage": "done"
+        }
+      ]
+    }
+  ],
+  "current_milestone": 1,
+  "phase_map": {}
+}
+```
+
+### Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `current_milestone` | 1-indexed pointer to the active milestone. Advanced automatically when a milestone completes. |
+| `pipeline_stage` (per issue) | Progress: `new` -> `triaged` -> `planning` -> `executing` -> `verifying` -> `pr-created` -> `done` (or `failed` / `blocked`) |
+| `depends_on_slugs` | Slugified issue titles for dependency resolution |
+| `phase_number` | Ordering within a milestone |
+
+---
+
+## Issue State Files
+
+Each in-progress issue has a JSON file at `.mgw/active/<number>-<slug>.json`:
+
+```json
+{
+  "issue": {
+    "number": 42,
+    "title": "Fix authentication flow",
+    "url": "https://github.com/owner/repo/issues/42",
+    "labels": ["bug"],
+    "assignee": "username"
+  },
+  "triage": {
+    "scope": { "files": 5, "systems": ["auth", "middleware"] },
+    "validity": "confirmed",
+    "security_notes": "Touches auth tokens -- review required",
+    "conflicts": [],
+    "last_comment_count": 3,
+    "last_comment_at": "2026-02-26T10:00:00Z"
+  },
+  "gsd_route": "quick",
+  "gsd_artifacts": { "type": "quick", "path": ".planning/quick/01-fix-auth" },
+  "pipeline_stage": "executing",
+  "comments_posted": ["triage-complete", "work-started"],
+  "linked_pr": null,
+  "linked_issues": [],
+  "linked_branches": ["issue/42-fix-auth"]
+}
+```
+
+### Issue State Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue.number` | number | GitHub issue number |
+| `issue.title` | string | Issue title |
+| `issue.url` | string | Full GitHub URL |
+| `issue.labels` | string[] | GitHub labels |
+| `issue.assignee` | string | GitHub username |
+| `triage.scope.files` | number | Estimated file count |
+| `triage.scope.systems` | string[] | Affected systems/modules |
+| `triage.validity` | string | `"confirmed"`, `"unconfirmed"`, or `"invalid"` |
+| `triage.security_notes` | string | Security concerns (empty if none) |
+| `triage.conflicts` | string[] | Conflicting issues |
+| `triage.last_comment_count` | number | Comment count at triage time |
+| `triage.last_comment_at` | string/null | Last comment timestamp at triage |
+| `gsd_route` | string | GSD route: `quick`, `quick --full`, `plan-phase`, `new-milestone`, etc. |
+| `gsd_artifacts.type` | string/null | Artifact type |
+| `gsd_artifacts.path` | string/null | Path to `.planning/` artifacts |
+| `pipeline_stage` | string | Current stage (see [[Architecture]]) |
+| `comments_posted` | string[] | Stage tags of comments already posted |
+| `linked_pr` | number/null | PR number if created |
+| `linked_issues` | number[] | Related issue numbers |
+| `linked_branches` | string[] | Associated branch names |
+
+---
+
+## cross-refs.json
+
+Tracks bidirectional relationships:
+
+```json
+{
+  "links": [
+    { "a": "issue:42", "b": "issue:43", "type": "related", "created": "2026-02-26T10:00:00Z" },
+    { "a": "issue:42", "b": "pr:15", "type": "implements", "created": "2026-02-26T12:00:00Z" },
+    { "a": "issue:42", "b": "branch:issue/42-fix-auth", "type": "tracks", "created": "2026-02-26T10:00:00Z" }
+  ]
+}
+```
+
+### Link Types
+
+| From | To | Type | Meaning |
+|------|----|------|---------|
+| issue | issue | `related` | General cross-reference |
+| issue | issue | `blocked-by` | Dependency relationship |
+| issue | pr | `implements` | PR resolves the issue |
+| issue | branch | `tracks` | Branch contains work for the issue |
+| pr | branch | `tracks` | PR is based on the branch |
+
+---
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `NO_COLOR` | Disable colored terminal output |
+| `CI` | Detected automatically; disables color and interactive prompts |
+
+---
+
+## CLI Global Options
+
+Every CLI subcommand supports:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would happen without executing |
+| `--json` | Output structured JSON instead of formatted text |
+| `-v, --verbose` | Show API calls and file writes |
+| `--debug` | Full payloads, timings, and internal state |
+| `--model <model>` | Override the Claude model for AI-dependent commands (e.g., `--model claude-opus-4-6`) |
+
+---
+
+## GitHub Issue Templates
+
+`/mgw:init` creates two issue templates in `.github/ISSUE_TEMPLATE/`:
+
+- **`bug_report.yml`** -- Fields: BLUF, What's Wrong, What's Involved, Steps to Fix, Additional Context
+- **`feature_request.yml`** -- Fields: BLUF, What's Needed, What's Involved, Additional Context
+
+These structured fields help MGW's triage agent extract requirements more reliably. You can customize the templates -- MGW will work with any issue body, but structured templates produce better triage results.
+
+---
+
+## PR Template
+
+`.github/PULL_REQUEST_TEMPLATE.md` provides the base structure:
+
+```markdown
+## Summary
+<!-- 2-4 bullets: what changed and why -->
+
+Closes #<!-- issue number -->
+
+## Changes
+<!-- Group by system/module -->
+
+## Test Plan
+<!-- How to verify these changes work -->
+```
+
+When MGW creates PRs via `/mgw:pr` or `/mgw:run`, it fills in these sections automatically from GSD artifacts and milestone context.
+
+---
+
+## Worktree Configuration
+
+MGW creates git worktrees in `.worktrees/` for each issue pipeline:
+
+```
+.worktrees/
+  issue/42-fix-auth/     # Full checkout on branch issue/42-fix-auth
+  issue/71-user-reg/     # Full checkout on branch issue/71-user-reg
+```
+
+Both `.mgw/` and `.worktrees/` are added to `.gitignore` by `/mgw:init`.
+
+The `.mgw/` directory is **not** inside worktrees. It only exists in the main repository checkout. All state operations during `/mgw:run` use absolute paths back to the main repo.
+
+---
+
+## Slug Format
+
+Slugs are derived from issue titles: lowercase, spaces replaced with hyphens, truncated to 40 characters.
+
+```
+"Design Core Game Loop and Player Mechanics"
+-> "design-core-game-loop-and-player-mechanic"  (truncated at 40 chars)
+```
+
+MGW uses `gsd-tools.cjs generate-slug` for consistent slug generation.
+
+---
+
+## Manual State Editing
+
+If pipeline state gets out of sync, you can edit the JSON files directly:
+
+```bash
+# Mark an issue as done manually
+cat .mgw/active/42-fix-auth.json | jq '.pipeline_stage = "done"' > /tmp/fix.json
+mv /tmp/fix.json .mgw/active/42-fix-auth.json
+
+# Move it to completed
+mv .mgw/active/42-fix-auth.json .mgw/completed/
+
+# Reconcile
+mgw sync
+```
+
+### Complete Reset
+
+```bash
+rm -rf .mgw/
+/mgw:init
+```
+
+This preserves GitHub issues, milestones, and PRs but resets all local tracking state.
+
+---
+
+## Next Steps
+
+- [[Commands Reference]] -- What every command does
+- [[Architecture]] -- How state flows through the system
+- [[Troubleshooting]] -- When state goes wrong

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,247 @@
+# Getting Started
+
+This page covers everything you need to install MGW, set up your environment, and run your first pipeline.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [Node.js](https://nodejs.org/) | >= 18 | Runtime for the CLI |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) | Latest | AI execution engine |
+| [GitHub CLI](https://cli.github.com/) (`gh`) | Latest | GitHub API access |
+| [Get Shit Done](https://github.com/glittercowboy/get-shit-done) (GSD) | Latest | Planning and execution framework |
+
+Verify your prerequisites:
+
+```bash
+node --version          # >= 18.0.0
+claude --version        # Claude Code CLI
+gh auth status          # Must be authenticated
+ls ~/.claude/get-shit-done/bin/gsd-tools.cjs  # GSD installed
+```
+
+> **Note:** Not all commands require all prerequisites. See [[Commands Reference]] for which commands need Claude Code and GSD vs. which work with just Node.js and the GitHub CLI.
+
+---
+
+## Installation
+
+### Option 1: Full Install (CLI + Slash Commands)
+
+This gives you both the standalone `mgw` CLI and the `/mgw:*` slash commands in Claude Code.
+
+```bash
+git clone https://github.com/snipcodeit/mgw.git
+cd mgw
+npm install && npm run build
+npm link
+
+# Deploy slash commands to Claude Code
+mkdir -p ~/.claude/commands/mgw/workflows
+cp -r .claude/commands/mgw/* ~/.claude/commands/mgw/
+```
+
+After linking, the `mgw` CLI is available globally:
+
+```bash
+mgw --version
+mgw --help
+```
+
+### Option 2: npx (No Install)
+
+Try MGW without installing anything:
+
+```bash
+# See available commands
+npx mgw --help
+
+# List your open issues
+npx mgw issues
+
+# Sync local state with GitHub
+npx mgw sync
+
+# Cross-reference two issues
+npx mgw link 42 43
+```
+
+`npx mgw` gives you the CLI subset that works without Claude Code. For the AI-powered pipeline commands (`run`, `issue`, `project`, `milestone`, etc.), do the full install.
+
+### Option 3: Slash Commands Only (No CLI)
+
+If you only want the Claude Code integration:
+
+```bash
+git clone https://github.com/snipcodeit/mgw.git
+mkdir -p ~/.claude/commands/mgw/workflows
+cp -r mgw/.claude/commands/mgw/* ~/.claude/commands/mgw/
+```
+
+### Option 4: Per-Project Slash Commands
+
+To scope MGW commands to a specific project instead of installing globally:
+
+```bash
+cd your-project
+mkdir -p .claude/commands/mgw/workflows
+cp -r /path/to/mgw/.claude/commands/mgw/* .claude/commands/mgw/
+```
+
+---
+
+## Verify Installation
+
+```bash
+# CLI verification
+mgw --version
+
+# Slash command verification
+ls ~/.claude/commands/mgw/
+# Expected: ask.md help.md init.md issue.md issues.md link.md
+#           milestone.md next.md pr.md project.md review.md
+#           run.md status.md sync.md update.md workflows/
+```
+
+Then inside Claude Code:
+
+```
+/mgw:help
+```
+
+---
+
+## npx vs Full Install
+
+Not all commands work via `npx`. The CLI has two tiers:
+
+| Tier | Commands | Requirements |
+|------|----------|--------------|
+| **CLI-only** (works with npx) | `issues`, `sync`, `link`, `help`, `--help`, `--version` | Node.js >= 18, `gh` CLI |
+| **AI-powered** (requires full install) | `run`, `init`, `project`, `milestone`, `next`, `issue`, `update`, `pr` | Node.js >= 18, `gh` CLI, Claude Code CLI, GSD |
+
+AI-powered commands call `claude -p` under the hood and require the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/overview) to be installed and authenticated. The slash command `.md` files must also be deployed to `~/.claude/commands/mgw/` for the full pipeline to work.
+
+---
+
+## Bootstrap a Repository
+
+Before using MGW in a repository, run the one-time setup:
+
+```
+/mgw:init
+```
+
+This creates:
+
+- `.mgw/` state directory (gitignored)
+- `.mgw/cross-refs.json` for tracking links between issues, PRs, and branches
+- GitHub issue templates (bug report + enhancement)
+- GitHub PR template
+- Standard labels on the repository
+- `.gitignore` entries for `.mgw/` and `.worktrees/`
+
+The init command is safe to re-run. It skips anything that already exists.
+
+---
+
+## Your First Pipeline
+
+### Scenario 1: Run a Single Issue
+
+If your repo already has open GitHub issues:
+
+```bash
+# 1. See what's assigned to you
+/mgw:issues
+
+# 2. Pick an issue and run the full pipeline
+/mgw:run 42
+# Creates branch, triages, plans via GSD, executes, opens PR
+
+# 3. Review the PR, merge when ready
+```
+
+### Scenario 2: Scaffold a New Project
+
+Starting from scratch:
+
+```bash
+# 1. Initialize the repo for MGW
+/mgw:init
+
+# 2. Scaffold milestones and issues from your description
+/mgw:project
+# MGW asks: "What are you building?"
+# Generates milestones, phases, and issues.
+
+# 3. See the execution plan
+/mgw:milestone --dry-run
+
+# 4. Execute the first milestone
+/mgw:milestone
+# Runs each issue in dependency order, creating PRs as it goes
+
+# 5. Review and merge PRs as they are created
+```
+
+### Scenario 3: Manual Step-by-Step
+
+For more control:
+
+```bash
+# Triage first
+/mgw:issue 42
+
+# Link related issues
+/mgw:link 42 #43
+
+# Run the pipeline (skips triage since already done)
+/mgw:run 42
+
+# Or create a PR manually
+/mgw:pr 42 --base develop
+```
+
+---
+
+## What Happens During `/mgw:run`
+
+When you run `/mgw:run 42`, here is the full sequence:
+
+1. **Validate** -- Load or create triage state for issue #42
+2. **Worktree** -- Create isolated git worktree at `.worktrees/issue/42-<slug>/`
+3. **Pre-flight** -- Check for new comments since triage
+4. **Triage comment** -- Post structured triage results on the GitHub issue
+5. **GSD execution** -- Run the appropriate GSD route (quick, quick --full, or new-milestone)
+6. **Execution comment** -- Post commit count and file changes on the issue
+7. **PR creation** -- Push branch, create PR with milestone context and test plan
+8. **PR-ready comment** -- Post PR link on the issue
+9. **Cleanup** -- Remove worktree, update state to `done`
+
+Your main workspace stays on the default branch throughout. All work happens in the isolated worktree.
+
+---
+
+## Uninstalling
+
+```bash
+# Remove CLI
+npm unlink mgw
+
+# Remove slash commands
+rm -rf ~/.claude/commands/mgw/
+
+# Remove local state (per-repo, if initialized)
+rm -rf .mgw/
+```
+
+---
+
+## Next Steps
+
+- [[Commands Reference]] -- Full documentation for every command
+- [[Workflow Guide]] -- End-to-end walkthroughs with examples
+- [[Configuration]] -- Customize MGW for your workflow

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,104 @@
+# MGW -- My GSD Workflow
+
+> Issue in. PR out. No excuses.
+
+**MGW** is a GitHub-native issue-to-PR automation tool for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), powered by [Get Shit Done](https://github.com/glittercowboy/get-shit-done) (GSD).
+
+Point it at a GitHub issue. It triages the issue, plans the work, executes through GSD, and opens a pull request -- posting structured status comments at every stage.
+
+```
+/mgw:run 42
+```
+
+That's it. One command takes an issue from open to PR-ready.
+
+---
+
+## How It Works
+
+```
+GitHub Issue #42
+    |
+    v
+MGW triages (scope, validity, security, conflicts)
+    |
+    v
+MGW creates isolated worktree
+    |
+    v
+GSD plans and executes code changes
+    |
+    v
+MGW creates PR with structured description
+    |
+    v
+PR #85 ready for review -- issue auto-closes on merge
+```
+
+MGW handles the orchestration (GitHub metadata, state tracking, status comments, PR creation). GSD handles the execution (planning, coding, verification). MGW never touches application code.
+
+---
+
+## Quick Navigation
+
+| Page | Description |
+|------|-------------|
+| [[Getting Started]] | Installation, prerequisites, first run |
+| [[Commands Reference]] | All `/mgw:*` commands with usage, flags, and examples |
+| [[Workflow Guide]] | End-to-end walkthroughs: triage to PR, milestone execution |
+| [[Architecture]] | Two-layer model, pipeline flow, state management, agent delegation |
+| [[Configuration]] | `.mgw/` directory, project.json, config.json, templates |
+| [[Troubleshooting]] | Common issues and solutions |
+
+---
+
+## Who This Is For
+
+MGW is for **solo developers and small teams using Claude Code** who want their GitHub history to reflect the work they actually did -- without spending time on project management.
+
+You'll get the most out of MGW if you:
+
+- Use [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) as your primary development tool
+- Have a pile of GitHub issues that never get proper status updates or PR descriptions
+- Want a repeatable issue-to-PR pipeline that handles triage, planning, execution, and documentation automatically
+- Work across multiple projects and lose context switching between GitHub and your terminal
+
+---
+
+## Key Concepts
+
+### The Two-Layer Model
+
+MGW and GSD serve distinct roles:
+
+- **MGW** (orchestration layer) -- owns GitHub metadata, pipeline state, status comments, PR creation, worktree management
+- **GSD** (execution layer) -- owns planning, coding, verification, `.planning/` directory
+
+MGW never writes application code. GSD never writes to `.mgw/`. This separation is the core architectural principle.
+
+### Pipeline Stages
+
+Every issue progresses through:
+
+```
+new --> triaged --> planning --> executing --> verifying --> pr-created --> done
+```
+
+### GSD Routes
+
+MGW selects a GSD route based on issue scope:
+
+| Issue Size | Files | Route | Description |
+|-----------|-------|-------|-------------|
+| Small | 1-2 | `quick` | Single-pass plan + execute |
+| Medium | 3-8 | `quick --full` | Plan with verification loop |
+| Large | 9+ | `new-milestone` | Full milestone with phased execution |
+
+---
+
+## Links
+
+- [GitHub Repository](https://github.com/snipcodeit/mgw)
+- [npm Package](https://www.npmjs.com/package/mgw)
+- [Get Shit Done (GSD)](https://github.com/glittercowboy/get-shit-done)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,407 @@
+# Troubleshooting
+
+Common issues and their solutions when working with MGW.
+
+---
+
+## Authentication Issues
+
+### GitHub CLI Not Authenticated
+
+```
+Error: gh: not logged in
+```
+
+**Fix:** Run `gh auth status` to check. If not authenticated:
+
+```bash
+gh auth login
+# Select GitHub.com, HTTPS, and authenticate via browser
+```
+
+MGW requires the `repo` scope. If you are authenticated but getting permission errors:
+
+```bash
+gh auth login --scopes repo
+```
+
+### Claude CLI Not Installed
+
+```
+Error: claude CLI is not installed.
+Install it with: npm install -g @anthropic-ai/claude-code
+Then run: claude login
+```
+
+**Fix:** Install Claude Code and authenticate. Non-AI commands (`sync`, `issues`, `link`, `help`) work without Claude -- see [[Commands Reference]] for which commands require it.
+
+### Claude CLI Not Authenticated
+
+```
+Error: claude CLI is not authenticated.
+Run: claude login
+```
+
+**Fix:** Run `claude login` and follow the prompts.
+
+---
+
+## GSD Issues
+
+### GSD Not Installed
+
+```
+Error: GSD slash commands not found
+```
+
+**Fix:** Install GSD at the standard location:
+
+```bash
+git clone https://github.com/glittercowboy/get-shit-done.git ~/.claude/get-shit-done
+```
+
+Verify:
+
+```
+/gsd:quick --help
+```
+
+### GSD Tools Not Found
+
+```
+Error: GSD tools not found at ~/.claude/get-shit-done/bin/gsd-tools.cjs
+```
+
+**Fix:** Ensure GSD is installed at `~/.claude/get-shit-done/`. If it is installed elsewhere, check if a symlink exists.
+
+---
+
+## State Issues
+
+### State Drift
+
+Local `.mgw/` state can fall out of sync with GitHub if you merge PRs from the web UI, close issues manually, or work from a different machine.
+
+**Fix:**
+
+```
+/mgw:sync
+```
+
+This archives completed issues, flags stale branches, and catches drift.
+
+### Corrupted State Files
+
+If `.mgw/` JSON files become corrupted:
+
+```bash
+# Validate JSON
+python3 -c "import json; json.load(open('.mgw/project.json'))"
+
+# If corrupt, remove and re-initialize
+rm -rf .mgw/
+/mgw:init
+/mgw:project   # If you need project tracking
+```
+
+### Missing `.mgw/` Directory
+
+If you cloned a repo that uses MGW but don't have a `.mgw/` directory:
+
+```
+/mgw:init
+```
+
+This won't affect anything on GitHub. The `.mgw/` directory is local-only and gitignored.
+
+### No Project Initialized
+
+```
+Error: No project initialized
+```
+
+Commands like `/mgw:next` and `/mgw:milestone` require project state.
+
+**Fix:** Either scaffold a project:
+
+```
+/mgw:project
+```
+
+Or run individual issues without project state:
+
+```
+/mgw:run 42
+```
+
+`/mgw:run` works with or without `project.json`.
+
+---
+
+## Worktree Issues
+
+### Stale Worktrees After Crash
+
+If a session ends without cleaning up worktrees:
+
+```bash
+# List active worktrees
+git worktree list
+
+# Remove a specific worktree
+git worktree remove .worktrees/issue/42-fix-auth
+
+# Force remove if there are uncommitted changes
+git worktree remove .worktrees/issue/42-fix-auth --force
+
+# Prune all stale worktree references
+git worktree prune
+
+# Clean up empty directories
+rmdir .worktrees/issue .worktrees 2>/dev/null
+```
+
+The associated branches are not deleted automatically. Clean them up after removing the worktree:
+
+```bash
+git branch -d issue/42-fix-auth
+```
+
+### Branch Already Exists
+
+```
+Error: Branch already exists
+```
+
+A previous pipeline run created the branch.
+
+**Fix:** Delete the branch and retry:
+
+```bash
+git branch -D issue/42-fix-auth
+/mgw:run 42
+```
+
+Or use the existing branch if the work is still relevant.
+
+---
+
+## Pipeline Issues
+
+### Pipeline Failed (No PR Created)
+
+When `/mgw:run` fails to produce a PR:
+
+1. **Check the issue comments** -- MGW posts a `pipeline-failed` comment with details
+2. **Check for a lingering worktree:**
+   ```bash
+   git worktree list
+   cd .worktrees/issue/42-fix-auth
+   git log --oneline
+   ```
+3. **Clean up and retry:**
+   ```bash
+   git worktree remove .worktrees/issue/42-fix-auth
+   /mgw:run 42
+   ```
+
+### Blocked by Stakeholder Comment
+
+If a blocking comment is detected during pre-flight:
+
+1. Pipeline pauses with `pipeline_stage: "blocked"`
+2. A `pipeline-blocked` comment is posted
+3. **Fix:** Resolve the blocker (reply on the issue, update requirements)
+4. Re-run: `/mgw:run 42`
+
+### No GSD Route Determined
+
+```
+Error: No GSD route determined
+```
+
+Triage couldn't determine issue scope.
+
+**Fix:** Run triage manually to inspect the output:
+
+```
+/mgw:issue 42
+```
+
+### Merge Conflict in Worktree
+
+The main branch diverged during execution.
+
+**Fix:** Resolve conflicts in the worktree, then resume:
+
+```
+/mgw:run 42
+```
+
+---
+
+## GitHub API Issues
+
+### Rate Limiting
+
+```
+Error: API rate limit exceeded
+```
+
+MGW posts comments on issues at each pipeline stage. If you're executing many issues quickly via `/mgw:milestone`, you may hit rate limits.
+
+**Check your current rate limit:**
+
+```bash
+gh api rate_limit --jq '.resources.core'
+```
+
+**Fix:** Wait for the reset window (usually under an hour) or reduce concurrent pipelines. Authenticated requests get 5,000 requests per hour.
+
+### Issue Not Found
+
+```
+Error: Issue #N not found
+```
+
+The issue doesn't exist or is in a different repo.
+
+**Fix:** Check the issue number and ensure you are in the correct repo.
+
+### Permission Denied
+
+```
+Error: Permission denied
+```
+
+GitHub token lacks required scopes.
+
+**Fix:** Re-authenticate:
+
+```bash
+gh auth login --scopes repo
+```
+
+---
+
+## Dependency Issues
+
+### Circular Dependencies
+
+If `/mgw:milestone` reports a circular dependency:
+
+1. Check the reported issue slugs
+2. Review `blocked-by` labels on GitHub
+3. Remove the circular label:
+   ```bash
+   gh issue edit 42 --remove-label "blocked-by:#43"
+   ```
+4. Update `depends_on_slugs` in `.mgw/project.json` if needed
+5. Re-run: `/mgw:milestone`
+
+---
+
+## Slash Command Issues
+
+### Slash Commands Not Appearing in Claude Code
+
+```bash
+# Verify commands are deployed
+ls ~/.claude/commands/mgw/
+# Should list .md files
+
+# If missing, redeploy
+mkdir -p ~/.claude/commands/mgw/workflows
+cp -r /path/to/mgw/.claude/commands/mgw/* ~/.claude/commands/mgw/
+```
+
+### Not a Git Repository
+
+```
+Error: Not a git repository
+```
+
+MGW requires a git repository with a GitHub remote.
+
+**Verify:**
+
+```bash
+git rev-parse --show-toplevel
+gh repo view
+```
+
+---
+
+## Common Errors Quick Reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Issue #N not found` | Issue doesn't exist or wrong repo | Check issue number and repo |
+| `Branch already exists` | Previous pipeline created the branch | Delete branch or use existing |
+| `No GSD route determined` | Triage couldn't determine scope | Run `/mgw:issue N` manually |
+| `Merge conflict in worktree` | Main branch diverged during execution | Resolve conflicts, then resume |
+| `Permission denied` | Token lacks scopes | `gh auth login --scopes repo` |
+| `API rate limit exceeded` | Too many API calls | Wait for reset or reduce concurrency |
+| `GSD tools not found` | GSD not installed | Clone GSD to `~/.claude/get-shit-done/` |
+| `claude CLI is not installed` | Claude Code not installed | Install and authenticate Claude Code |
+| `No project initialized` | Missing project.json | Run `/mgw:project` or use `/mgw:run` directly |
+
+---
+
+## Resuming After Failure
+
+### `/mgw:run` Failed Mid-Execution
+
+The worktree and branch still exist. Simply re-run:
+
+```
+/mgw:run 42
+```
+
+MGW detects existing state and resumes.
+
+### `/mgw:milestone` Failed
+
+Re-run -- completed issues are skipped:
+
+```
+/mgw:milestone
+```
+
+### Complete Reset
+
+If nothing else works:
+
+```bash
+# Clean up worktrees
+git worktree prune
+rm -rf .worktrees/
+
+# Reset state
+rm -rf .mgw/
+/mgw:init
+```
+
+---
+
+## Uninstalling MGW
+
+```bash
+# Remove CLI
+npm unlink mgw
+
+# Remove slash commands
+rm -rf ~/.claude/commands/mgw/
+
+# Remove local state (per-repo, if initialized)
+rm -rf .mgw/
+```
+
+---
+
+## Next Steps
+
+- [[Commands Reference]] -- Full command documentation
+- [[Configuration]] -- State files and settings
+- [[Workflow Guide]] -- Usage patterns
+- [[Home]] -- Back to overview

--- a/wiki/Workflow-Guide.md
+++ b/wiki/Workflow-Guide.md
@@ -1,0 +1,407 @@
+# Workflow Guide
+
+End-to-end walkthroughs covering common MGW usage patterns, from single-issue runs to full milestone execution.
+
+---
+
+## Greenfield Project
+
+Starting a brand new project from scratch:
+
+```
+# Step 1: Initialize the repo for MGW
+/mgw:init
+
+# Step 2: Scaffold milestones and issues from your description
+/mgw:project
+# MGW asks: "What are you building?"
+# You describe your project. MGW generates milestones, phases, and issues.
+
+# Step 3: See the execution plan
+/mgw:milestone --dry-run
+# Shows: ordered issues, dependencies, estimated API calls
+
+# Step 4: Execute the first milestone
+/mgw:milestone
+# Runs each issue in dependency order:
+#   - Posts work-started comment
+#   - Creates worktree
+#   - Plans via GSD
+#   - Executes code changes
+#   - Creates PR
+#   - Posts PR-ready comment
+#   - Cleans up worktree
+
+# Step 5: Review and merge PRs as they are created
+# Each merged PR auto-closes its linked issue
+
+# Step 6: After merging, sync state
+/mgw:sync
+```
+
+---
+
+## Existing Issues
+
+Working with a repo that already has GitHub issues:
+
+```
+# Step 1: See what is assigned to you
+/mgw:issues
+
+# Step 2: Find the next unblocked issue
+/mgw:next
+
+# Step 3: Run the full pipeline for that issue
+/mgw:run 42
+# Creates branch issue/42-fix-auth in a worktree
+# Triages (if not already done)
+# Plans and executes via GSD
+# Opens PR with structured description
+# Posts status comments on the issue
+
+# Step 4: Review the PR, merge when ready
+
+# Step 5: Sync state
+/mgw:sync
+```
+
+---
+
+## Manual Step-by-Step Control
+
+For more control over individual pipeline stages:
+
+```
+# Triage first
+/mgw:issue 42
+
+# Review triage results, then link related issues
+/mgw:link 42 #43
+
+# Post a status update
+/mgw:update 42 "starting implementation"
+
+# Run the pipeline (skips triage since it is already done)
+/mgw:run 42
+
+# Or create a PR manually from the current branch
+/mgw:pr 42 --base develop
+```
+
+---
+
+## Working Across Multiple Sessions
+
+MGW checkpoints state after each issue. If your session ends mid-milestone:
+
+```
+# Session 1: Start milestone execution
+/mgw:milestone
+# Completes issues #10, #11, #12 -- session ends
+
+# Session 2: Resume where you left off
+/mgw:milestone
+# Detects #10, #11, #12 are done
+# Continues with #13, #14, ...
+```
+
+If an issue was partially in progress when the session ended, `/mgw:milestone` detects this, cleans up the partial worktree, and restarts that issue from scratch.
+
+---
+
+## The `/mgw:run` Pipeline in Detail
+
+When you run `/mgw:run 42`, here is the full sequence:
+
+### Stage 1: Validate and Load
+
+```
+Parse issue number from arguments
+Check .mgw/active/ for existing state
+If no state: run triage inline
+```
+
+### Stage 2: Create Worktree
+
+```
+Derive branch name: issue/42-fix-auth
+git worktree add .worktrees/issue/42-fix-auth
+cd into worktree (all work happens here)
+```
+
+### Stage 3: Pre-Flight Comment Check
+
+```
+Compare current comment count with triage snapshot
+If new comments: spawn classification agent
+  - material  --> enrich context, continue
+  - blocking  --> pause pipeline
+  - informational --> log, continue
+```
+
+### Stage 4: Post Triage Comment
+
+```
+Post structured comment on issue:
+  scope, route, files, security, branch name
+```
+
+### Stage 5: GSD Execution
+
+Depending on the triage-determined route:
+
+**Quick route:**
+1. Initialize GSD quick project
+2. Spawn planner agent --> creates PLAN.md
+3. (if --full) Spawn plan checker agent
+4. Spawn executor agent --> writes code, creates commits
+5. (if --full) Spawn verifier agent
+6. Verify artifacts
+
+**Milestone route:**
+1. Initialize GSD new-milestone
+2. Spawn roadmapper agent
+3. For each phase: plan, execute, verify, post phase-complete comment
+
+### Stage 6: Post Execution Comment
+
+```
+Post on issue: commit count, file changes, test status
+```
+
+### Stage 7: Create PR
+
+```
+git push -u origin issue/42-fix-auth
+Read GSD artifacts (SUMMARY.md, VERIFICATION.md)
+Create PR with: summary, milestone context, changes, test plan
+```
+
+### Stage 8: Cleanup
+
+```
+cd back to repo root
+git worktree remove
+Post pr-ready comment on issue
+Update state: pipeline_stage = "done"
+```
+
+---
+
+## Milestone Execution Flow
+
+`/mgw:milestone` is the highest-level orchestrator. Here is how it processes a milestone:
+
+```
+Load project.json
+    |
+    v
+Topological sort (Kahn's algorithm)
+    |
+    v
+Rate limit guard (estimate API calls)
+    |
+    v
+For each issue in sorted order:
+    |
+    +-- Check: blocked by a failed dependency? --> skip
+    +-- Check: rate limit exceeded? --> stop
+    +-- Check: issue still open on GitHub? --> skip if closed
+    |
+    +-- Post work-started comment (with milestone progress table)
+    +-- Run /mgw:run via Task()
+    +-- Detect result (PR created or failed)
+    +-- Post pr-ready or pipeline-failed comment
+    +-- Checkpoint to project.json
+    |
+    v
+All done? --> Close milestone, create draft release, advance pointer
+Some failed? --> Report, do not close milestone
+```
+
+### What Happens When a Dependency Fails
+
+1. The failed issue is marked with `pipeline_stage: "failed"` and labeled `pipeline-failed`
+2. All issues that depend on the failed issue are marked as blocked
+3. Issues that do **not** depend on the failed issue continue executing
+4. The milestone is marked as incomplete
+
+To recover:
+
+```
+# Fix the underlying problem, then re-run
+/mgw:milestone
+# Completed issues are skipped, failed issue retries
+```
+
+### Interactive Mode
+
+For careful, step-by-step execution:
+
+```
+/mgw:milestone --interactive
+```
+
+After each issue completes, you choose: **Continue**, **Skip next**, or **Abort**.
+
+### Dry Run
+
+Preview the execution plan without running anything:
+
+```
+/mgw:milestone --dry-run
+```
+
+Displays a table showing order, issue number, title, current status, what each issue depends on, and what each issue blocks.
+
+---
+
+## Status Comments
+
+Every pipeline step posts a structured comment on the GitHub issue:
+
+```markdown
+> MGW . `work-started` . 2026-02-26T03:31:00Z
+> Milestone: v1.0 -- Auth & Data Layer | Phase 1: Database Schema
+
+### Work Started
+
+| | |
+|---|---|
+| **Issue** | #71 -- Implement user registration |
+| **Route** | `plan-phase` |
+| **Phase** | 1 of 6 -- Database Schema |
+| **Milestone** | v1.0 -- Auth & Data Layer |
+
+<details>
+<summary>Milestone Progress (1/6 complete)</summary>
+| # | Issue | Status | PR |
+|---|-------|--------|----|
+| 70 | Design SQLite schema | Done | #85 |
+| **71** | **User registration** | In Progress | -- |
+| 72 | JWT middleware | Pending | -- |
+</details>
+```
+
+### Comment Types
+
+| Stage | Tag | Content |
+|-------|-----|---------|
+| Triage complete | `triage-complete` | Scope, validity, security, route, affected files |
+| Work started | `work-started` | Issue details, route, phase, milestone progress table |
+| Execution complete | `execution-complete` | Commit count, file changes, test status |
+| PR ready | `pr-ready` | PR link, one-liner summary, pipeline stage table |
+| Pipeline failed | `pipeline-failed` | Failure notification, dependent issue impact |
+| Pipeline blocked | `pipeline-blocked` | Blocking comment detected, reason |
+| Phase complete | `phase-complete` | Per-phase summary during milestone execution |
+
+---
+
+## PR Description Structure
+
+PRs created by MGW follow a consistent structure:
+
+```markdown
+## Summary
+- 2-4 bullets of what was built and why
+
+Closes #42
+
+## Milestone Context
+- **Milestone:** v1.0 -- Core Features
+- **Phase:** 1 -- Database Schema
+- **Issue:** 2 of 6 in milestone
+
+## Changes
+- File-level changes grouped by module
+
+## Test Plan
+- Verification checklist
+
+## Cross-References
+- Related issues and PRs
+```
+
+The content is generated from GSD artifacts (SUMMARY.md, VERIFICATION.md) and MGW state (cross-refs.json, project.json). The PR agent never reads application code directly.
+
+---
+
+## GSD Routes Explained
+
+MGW selects a GSD route based on issue scope during triage:
+
+| Issue Size | Files | Route | What Happens |
+|-----------|-------|-------|--------------|
+| Small | 1-2 | `quick` | Single-pass plan + execute. Fast, minimal overhead. |
+| Medium | 3-8 | `quick --full` | Plan with verification loop. Includes plan checking and post-execution verification. |
+| Large | 9+ | `new-milestone` | Full milestone with phased execution. Roadmap creation, multi-phase planning, per-phase verification. |
+
+### All Available GSD Routes
+
+| Route | Use Case |
+|-------|----------|
+| `quick` | Small, well-defined tasks. One plan, one execution pass. |
+| `plan-phase` | Complex multi-step implementation. Detailed planning with task breakdown. |
+| `discuss-phase` | Requirements clarification. Gather context before planning. |
+| `research-phase` | Unknowns requiring investigation before implementation. |
+| `execute-phase` | Straightforward mechanical execution (plan already exists). |
+| `verify-phase` | Post-execution verification against acceptance criteria. |
+| `new-project` | Full project scaffold from scratch. |
+| `new-milestone` | New milestone with roadmap, phases, and dependency chain. |
+| `complete-milestone` | Finalize a milestone (close, release, advance). |
+
+### Overriding the Route
+
+You can override the route after triage by editing the state file:
+
+```bash
+cat .mgw/active/42-fix-auth.json | jq '.gsd_route = "plan-phase"' > /tmp/fix.json
+mv /tmp/fix.json .mgw/active/42-fix-auth.json
+```
+
+Or delete the state file and re-triage:
+
+```bash
+rm .mgw/active/42-fix-auth.json
+/mgw:issue 42
+```
+
+---
+
+## Dependency Ordering
+
+### How Dependencies Are Declared
+
+During `/mgw:project`, issues are generated with `depends_on` slugs. On GitHub, dependencies appear as `blocked-by:#N` labels.
+
+### How Dependencies Are Resolved
+
+`/mgw:milestone` uses Kahn's algorithm (topological sort):
+
+1. Build a directed graph from `depends_on_slugs`
+2. Find all issues with zero in-degree (no unresolved dependencies)
+3. Process them in phase-number order (lower phase numbers first)
+4. After processing, decrement the in-degree of downstream issues
+5. Repeat until all issues are processed
+
+Circular dependencies are detected and reported. MGW refuses to proceed until they are resolved.
+
+### Adding a Dependency
+
+```bash
+# Create the label (if it does not exist)
+gh label create "blocked-by:#10" --description "Blocked by issue #10" --color "e4e669" --force
+
+# Apply it
+gh issue edit 42 --add-label "blocked-by:#10"
+```
+
+---
+
+## Next Steps
+
+- [[Commands Reference]] -- Full docs for every command
+- [[Architecture]] -- Deep dive into how the pipeline works
+- [[Configuration]] -- Customize MGW behavior
+- [[Troubleshooting]] -- When things go wrong

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,15 @@
+**MGW Wiki**
+
+---
+
+- [[Home]]
+- [[Getting Started]]
+- [[Commands Reference]]
+- [[Workflow Guide]]
+- [[Architecture]]
+- [[Configuration]]
+- [[Troubleshooting]]
+
+---
+
+[GitHub Repository](https://github.com/snipcodeit/mgw)

--- a/wiki/deploy.sh
+++ b/wiki/deploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Deploy MGW wiki pages to the GitHub wiki repository.
+#
+# Prerequisites:
+#   1. The wiki must be initialized on GitHub (create one page via the web UI first)
+#   2. You must have push access to the repository
+#
+# Usage:
+#   cd wiki/
+#   bash deploy.sh
+#
+# This script clones the wiki repo, copies all .md files, commits, and pushes.
+
+set -euo pipefail
+
+WIKI_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_URL="https://github.com/snipcodeit/mgw.wiki.git"
+TEMP_DIR=$(mktemp -d)
+
+echo "Cloning wiki repository..."
+if ! git clone "$REPO_URL" "$TEMP_DIR" 2>/dev/null; then
+    echo ""
+    echo "ERROR: Could not clone the wiki repository."
+    echo ""
+    echo "The wiki must be initialized first. To do this:"
+    echo "  1. Go to https://github.com/snipcodeit/mgw/wiki"
+    echo "  2. Click 'Create the first page'"
+    echo "  3. Save any content (it will be overwritten)"
+    echo "  4. Re-run this script"
+    echo ""
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+echo "Copying wiki pages..."
+# Remove existing content (except .git)
+find "$TEMP_DIR" -maxdepth 1 -not -name '.git' -not -name '.' -delete 2>/dev/null || true
+
+# Copy all .md files (excluding this deploy script's README if any)
+for f in "$WIKI_DIR"/*.md; do
+    [ -f "$f" ] && cp "$f" "$TEMP_DIR/"
+done
+
+cd "$TEMP_DIR"
+
+echo "Committing changes..."
+git add -A
+if git diff --cached --quiet; then
+    echo "No changes to commit. Wiki is up to date."
+else
+    git commit -m "docs: update MGW wiki with full documentation"
+    echo "Pushing to wiki..."
+    git push origin master || git push origin main
+    echo ""
+    echo "Wiki deployed successfully!"
+    echo "View at: https://github.com/snipcodeit/mgw/wiki"
+fi
+
+# Cleanup
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- Create comprehensive GitHub Wiki with 7 pages covering all MGW documentation: Home, Getting Started, Commands Reference, Workflow Guide, Architecture, Configuration, and Troubleshooting
- All pages cross-linked using `[[Page Name]]` wiki syntax with a `_Sidebar.md` for persistent navigation
- Include `wiki/deploy.sh` script to push pages to the wiki git repo once wiki is initialized via GitHub web UI
- Add wiki link to README Documentation table

Closes #54

## Milestone Context
- **Milestone:** v1 — Wiki & Final Polish
- **Phase:** 11 — Wiki
- **Issue:** 2 of 3 in milestone

## Changes
- **wiki/Home.md** — Overview, quick navigation table, key concepts (two-layer model, pipeline stages, GSD routes)
- **wiki/Getting-Started.md** — Prerequisites, 4 installation options, first pipeline walkthroughs, npx vs full install comparison
- **wiki/Commands-Reference.md** — All 15 `/mgw:*` commands with usage, flags, examples, and CLI equivalents
- **wiki/Workflow-Guide.md** — End-to-end walkthroughs (greenfield, existing issues, manual control, multi-session), detailed pipeline stages, milestone execution flow, status comments, GSD routes
- **wiki/Architecture.md** — Two-layer model, delegation boundary, pipeline data flow, state management, agent delegation model, slash command anatomy, CLI architecture, shared workflow system, GSD artifact flow
- **wiki/Configuration.md** — Full `.mgw/` directory structure, project.json schema, issue state schema, cross-refs.json, environment variables, CLI flags, templates, slug format
- **wiki/Troubleshooting.md** — Authentication, GSD, state, worktree, pipeline, API, dependency, and slash command issues with quick reference table
- **wiki/_Sidebar.md** — Persistent sidebar navigation for all wiki pages
- **wiki/deploy.sh** — Script to clone wiki repo and push all pages
- **README.md** — Add wiki link to Documentation table

## Deployment Note
The GitHub wiki git repository does not exist until the first page is created through the GitHub web UI. To deploy:
1. Navigate to https://github.com/snipcodeit/mgw/wiki
2. Click "Create the first page" and save any content
3. Run `cd wiki && bash deploy.sh` to push all pages

## Test Plan
- [ ] Verify all wiki `.md` files render correctly as standalone markdown
- [ ] Verify all `[[Page Name]]` links resolve to valid filenames (Page-Name.md)
- [ ] Verify `_Sidebar.md` includes links to all 7 pages
- [ ] Verify `deploy.sh` script runs without errors (after wiki is initialized)
- [ ] Verify README wiki link points to correct URL
- [ ] After deployment, verify cross-page navigation works in GitHub wiki UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)