### PR TITLE
feat(board): surface AI Agent State field during GSD execution

### DIFF
--- a/.claude/commands/mgw/run.md
+++ b/.claude/commands/mgw/run.md
@@ -38,6 +38,7 @@ Checkpoints requiring user input:
 @~/.claude/commands/mgw/workflows/github.md
 @~/.claude/commands/mgw/workflows/gsd.md
 @~/.claude/commands/mgw/workflows/validation.md
+@~/.claude/commands/mgw/workflows/board-sync.md
 </execution_context>
 
 <context>
@@ -55,6 +56,110 @@ Store repo root and default branch (used throughout):
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
 DEFAULT=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+Define the board sync utilities (non-blocking — see board-sync.md for full reference):
+```bash
+update_board_status() {
+  local ISSUE_NUMBER="$1"
+  local NEW_STAGE="$2"
+  if [ -z "$ISSUE_NUMBER" ] || [ -z "$NEW_STAGE" ]; then return 0; fi
+  BOARD_NODE_ID=$(python3 -c "
+import json,sys,os
+try:
+    p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    print(p.get('project',{}).get('project_board',{}).get('node_id',''))
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$BOARD_NODE_ID" ]; then return 0; fi
+  ITEM_ID=$(python3 -c "
+import json,sys
+try:
+    p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    for m in p.get('milestones',[]):
+        for i in m.get('issues',[]):
+            if i.get('github_number')==${ISSUE_NUMBER}:
+                print(i.get('board_item_id','')); sys.exit(0)
+    print('')
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$ITEM_ID" ]; then return 0; fi
+  FIELD_ID=$(python3 -c "
+import json,sys,os
+try:
+    s='${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(s):
+        print(json.load(open(s)).get('fields',{}).get('status',{}).get('field_id',''))
+    else:
+        p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        print(p.get('project',{}).get('project_board',{}).get('fields',{}).get('status',{}).get('field_id',''))
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$FIELD_ID" ]; then return 0; fi
+  OPTION_ID=$(python3 -c "
+import json,sys,os
+try:
+    stage='${NEW_STAGE}'
+    s='${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(s):
+        print(json.load(open(s)).get('fields',{}).get('status',{}).get('options',{}).get(stage,''))
+    else:
+        p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        print(p.get('project',{}).get('project_board',{}).get('fields',{}).get('status',{}).get('options',{}).get(stage,''))
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$OPTION_ID" ]; then return 0; fi
+  gh api graphql -f query='
+    mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){
+      updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optionId}}){projectV2Item{id}}
+    }
+  ' -f projectId="$BOARD_NODE_ID" -f itemId="$ITEM_ID" \
+    -f fieldId="$FIELD_ID" -f optionId="$OPTION_ID" 2>/dev/null || true
+}
+
+update_board_agent_state() {
+  local ISSUE_NUMBER="$1"
+  local STATE_TEXT="$2"
+  if [ -z "$ISSUE_NUMBER" ]; then return 0; fi
+  BOARD_NODE_ID=$(python3 -c "
+import json,sys,os
+try:
+    p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    print(p.get('project',{}).get('project_board',{}).get('node_id',''))
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$BOARD_NODE_ID" ]; then return 0; fi
+  ITEM_ID=$(python3 -c "
+import json,sys
+try:
+    p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    for m in p.get('milestones',[]):
+        for i in m.get('issues',[]):
+            if i.get('github_number')==${ISSUE_NUMBER}:
+                print(i.get('board_item_id','')); sys.exit(0)
+    print('')
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$ITEM_ID" ]; then return 0; fi
+  FIELD_ID=$(python3 -c "
+import json,sys,os
+try:
+    s='${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(s):
+        print(json.load(open(s)).get('fields',{}).get('ai_agent_state',{}).get('field_id',''))
+    else:
+        p=json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        print(p.get('project',{}).get('project_board',{}).get('fields',{}).get('ai_agent_state',{}).get('field_id',''))
+except: print('')
+" 2>/dev/null || echo "")
+  if [ -z "$FIELD_ID" ]; then return 0; fi
+  gh api graphql -f query='
+    mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$text:String!){
+      updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{text:$text}}){projectV2Item{id}}
+    }
+  ' -f projectId="$BOARD_NODE_ID" -f itemId="$ITEM_ID" \
+    -f fieldId="$FIELD_ID" -f text="$STATE_TEXT" 2>/dev/null || true
+}
 ```
 
 Parse $ARGUMENTS for issue number. If missing:
@@ -248,7 +353,7 @@ Return ONLY valid JSON:
 |---------------|--------|
 | **informational** | Log: "MGW: ${NEW_COUNT} new comment(s) reviewed — informational, continuing." Update `triage.last_comment_count` in state file. Continue pipeline. |
 | **material** | Log: "MGW: Material comment(s) detected — scope may have changed." Update state: add new_requirements to triage context. Update `triage.last_comment_count`. Re-read issue body for updated requirements. Continue with enriched context (pass new_requirements to planner). Check for security keywords in material comments (see below). |
-| **blocking** | Log: "MGW: Blocking comment detected — pipeline paused." Update state: `pipeline_stage = "blocked"`. Apply mgw:blocked label. Post comment on issue: `> **MGW** . \`pipeline-blocked\` . Blocked by stakeholder comment. Reason: ${blocking_reason}`. Stop pipeline execution. |
+| **blocking** | Log: "MGW: Blocking comment detected — pipeline paused." Update state: `pipeline_stage = "blocked"`. Apply mgw:blocked label. Call `update_board_status $ISSUE_NUMBER "blocked"` (non-blocking). Post comment on issue: `> **MGW** . \`pipeline-blocked\` . Blocked by stakeholder comment. Reason: ${blocking_reason}`. Stop pipeline execution. |
 
 **Security keyword check for material comments:**
 ```bash
@@ -339,6 +444,9 @@ Log comment in state file (at `${REPO_ROOT}/.mgw/active/`).
 Only run this step if gsd_route is "gsd:quick" or "gsd:quick --full".
 
 Update pipeline_stage to "executing" in state file (at `${REPO_ROOT}/.mgw/active/`).
+```bash
+update_board_status $ISSUE_NUMBER "executing"  # non-blocking board sync
+```
 
 Determine flags:
 - "gsd:quick" → $QUICK_FLAGS = ""
@@ -373,6 +481,9 @@ mkdir -p "$QUICK_DIR"
 ```
 
 3. **Spawn planner (task agent):**
+```bash
+update_board_agent_state $ISSUE_NUMBER "Planning"  # non-blocking agent state
+```
 ```
 Task(
   prompt="
@@ -475,6 +586,9 @@ If issues found and iteration < 2: spawn planner revision, then re-check.
 If iteration >= 2: offer force proceed or abort.
 
 7. **Spawn executor (task agent):**
+```bash
+update_board_agent_state $ISSUE_NUMBER "Executing"  # non-blocking agent state
+```
 ```
 Task(
   prompt="
@@ -506,6 +620,9 @@ VERIFY_RESULT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs verify-summary "$
 Parse JSON result. Use `passed` field for go/no-go. Checks summary existence, files created, and commits.
 
 9. **(If --full) Spawn verifier:**
+```bash
+update_board_agent_state $ISSUE_NUMBER "Verifying"  # non-blocking agent state
+```
 ```
 Task(
   prompt="
@@ -539,6 +656,9 @@ node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(quick-${next_num}): 
 ```
 
 Update state (at `${REPO_ROOT}/.mgw/active/`): gsd_artifacts.path = $QUICK_DIR, pipeline_stage = "verifying".
+```bash
+update_board_status $ISSUE_NUMBER "verifying"  # non-blocking board sync
+```
 </step>
 
 <step name="execute_gsd_milestone">
@@ -576,6 +696,7 @@ Set pipeline_stage to "discussing" and apply "mgw:discussing" label:
 ```bash
 gh issue edit ${ISSUE_NUMBER} --remove-label "mgw:in-progress" 2>/dev/null
 gh issue edit ${ISSUE_NUMBER} --add-label "mgw:discussing" 2>/dev/null
+update_board_status $ISSUE_NUMBER "discussing"  # non-blocking board sync
 ```
 
 Present to user:
@@ -623,6 +744,9 @@ If proceed: apply "mgw:approved" label and continue.
      ```
 
    Update pipeline_stage to "planning" (at `${REPO_ROOT}/.mgw/active/`).
+   ```bash
+   update_board_status $ISSUE_NUMBER "planning"  # non-blocking board sync
+   ```
 
 2. **If resuming with pipeline_stage = "planning" and ROADMAP.md exists:**
    Discover phases from ROADMAP and run the full per-phase GSD lifecycle:
@@ -661,6 +785,9 @@ If proceed: apply "mgw:approved" label and continue.
    ```
 
    **b. Spawn planner agent (gsd:plan-phase):**
+   ```bash
+   update_board_agent_state $ISSUE_NUMBER "Planning phase ${PHASE_NUMBER}"  # non-blocking agent state
+   ```
    ```
    Task(
      prompt="
@@ -707,6 +834,7 @@ If proceed: apply "mgw:approved" label and continue.
    ```bash
    EXEC_INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init execute-phase "${PHASE_NUMBER}")
    # Parse EXEC_INIT JSON for: executor_model, verifier_model, phase_dir, plans, incomplete_plans, plan_count
+   update_board_agent_state $ISSUE_NUMBER "Executing phase ${PHASE_NUMBER}"  # non-blocking agent state
    ```
    ```
    Task(
@@ -739,6 +867,9 @@ If proceed: apply "mgw:approved" label and continue.
    ```
 
    **e. Spawn verifier agent (gsd:verify-phase):**
+   ```bash
+   update_board_agent_state $ISSUE_NUMBER "Verifying phase ${PHASE_NUMBER}"  # non-blocking agent state
+   ```
    ```
    Task(
      prompt="
@@ -785,6 +916,9 @@ COMMENTEOF
    ```
 
    After ALL phases complete → update pipeline_stage to "verifying" (at `${REPO_ROOT}/.mgw/active/`).
+   ```bash
+   update_board_status $ISSUE_NUMBER "verifying"  # non-blocking board sync
+   ```
 </step>
 
 <step name="post_execution_update">
@@ -822,6 +956,9 @@ gh issue comment ${ISSUE_NUMBER} --body "$EXEC_BODY" 2>/dev/null || true
 ```
 
 Update pipeline_stage to "pr-pending" (at `${REPO_ROOT}/.mgw/active/`).
+```bash
+update_board_status $ISSUE_NUMBER "pr-created"  # non-blocking board sync (pr-pending maps to pr-created on board)
+```
 </step>
 
 <step name="create_pr">
@@ -992,6 +1129,11 @@ Update state (at `${REPO_ROOT}/.mgw/active/`):
 - linked_pr = PR number
 - pipeline_stage = "pr-created"
 
+```bash
+update_board_status $ISSUE_NUMBER "pr-created"  # non-blocking board sync
+update_board_agent_state $ISSUE_NUMBER ""  # clear agent state after PR creation (non-blocking)
+```
+
 Add cross-ref (at `${REPO_ROOT}/.mgw/cross-refs.json`): issue → PR.
 </step>
 
@@ -1052,6 +1194,9 @@ gh issue comment ${ISSUE_NUMBER} --body "$PR_READY_BODY" 2>/dev/null || true
 ```
 
 Update pipeline_stage to "done" (at `${REPO_ROOT}/.mgw/active/`).
+```bash
+update_board_status $ISSUE_NUMBER "done"  # non-blocking board sync
+```
 
 Report to user:
 ```
@@ -1092,5 +1237,9 @@ Next:
 - [ ] Worktree cleaned up, user returned to main workspace
 - [ ] mgw:in-progress label removed at completion
 - [ ] State file updated through all pipeline stages
+- [ ] Board Status field synced at each pipeline_stage transition (non-blocking)
+- [ ] AI Agent State field set before each GSD agent spawn (non-blocking)
+- [ ] AI Agent State field cleared after PR creation (non-blocking)
+- [ ] Board sync failures never block pipeline execution
 - [ ] User prompted to run /mgw:sync after merge
 </success_criteria>

--- a/.claude/commands/mgw/workflows/board-sync.md
+++ b/.claude/commands/mgw/workflows/board-sync.md
@@ -1,0 +1,304 @@
+<purpose>
+Shared board sync utilities for MGW pipeline commands. Two functions are exported:
+
+- update_board_status — Called after any pipeline_stage transition to update the board
+  item's Status (single-select) field.
+- update_board_agent_state — Called around GSD agent spawns to surface the active agent
+  in the board item's "AI Agent State" (text) field. Cleared after PR creation.
+
+All board updates are non-blocking: if the board is not configured, if the issue has no
+board_item_id, or if the API call fails, the function returns silently. A board sync
+failure MUST NEVER block pipeline execution.
+</purpose>
+
+## update_board_status
+
+Call this function after any `pipeline_stage` transition in any MGW command.
+
+```bash
+# update_board_status — Update board Status field after a pipeline_stage transition
+# Args: ISSUE_NUMBER, NEW_PIPELINE_STAGE
+# Non-blocking: all failures are silent no-ops
+update_board_status() {
+  local ISSUE_NUMBER="$1"
+  local NEW_STAGE="$2"
+
+  if [ -z "$ISSUE_NUMBER" ] || [ -z "$NEW_STAGE" ]; then
+    return 0
+  fi
+
+  # Read board project node ID from project.json (non-blocking — if not configured, skip)
+  BOARD_NODE_ID=$(python3 -c "
+import json, sys
+try:
+    p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    print(p.get('project', {}).get('project_board', {}).get('node_id', ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$BOARD_NODE_ID" ]; then return 0; fi
+
+  # Get board_item_id for this issue from project.json
+  ITEM_ID=$(python3 -c "
+import json, sys
+try:
+    p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    for m in p.get('milestones', []):
+        for i in m.get('issues', []):
+            if i.get('github_number') == ${ISSUE_NUMBER}:
+                print(i.get('board_item_id', ''))
+                sys.exit(0)
+    print('')
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$ITEM_ID" ]; then return 0; fi
+
+  # Map pipeline_stage to Status field option ID
+  # Reads from board-schema.json first, falls back to project.json fields
+  FIELD_ID=$(python3 -c "
+import json, sys, os
+try:
+    schema_path = '${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(schema_path):
+        s = json.load(open(schema_path))
+        print(s.get('fields', {}).get('status', {}).get('field_id', ''))
+    else:
+        p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        fields = p.get('project', {}).get('project_board', {}).get('fields', {})
+        print(fields.get('status', {}).get('field_id', ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$FIELD_ID" ]; then return 0; fi
+
+  OPTION_ID=$(python3 -c "
+import json, sys, os
+try:
+    stage = '${NEW_STAGE}'
+    schema_path = '${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(schema_path):
+        s = json.load(open(schema_path))
+        options = s.get('fields', {}).get('status', {}).get('options', {})
+        print(options.get(stage, ''))
+    else:
+        p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        fields = p.get('project', {}).get('project_board', {}).get('fields', {})
+        options = fields.get('status', {}).get('options', {})
+        print(options.get(stage, ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$OPTION_ID" ]; then return 0; fi
+
+  # Update the Status field on the board item (non-blocking)
+  gh api graphql -f query='
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { singleSelectOptionId: $optionId }
+      }) { projectV2Item { id } }
+    }
+  ' -f projectId="$BOARD_NODE_ID" \
+    -f itemId="$ITEM_ID" \
+    -f fieldId="$FIELD_ID" \
+    -f optionId="$OPTION_ID" 2>/dev/null || true
+}
+```
+
+## update_board_agent_state
+
+Call this function before spawning each GSD agent and after PR creation to surface
+real-time agent activity in the board item's "AI Agent State" text field.
+
+```bash
+# update_board_agent_state — Update AI Agent State text field on the board item
+# Args: ISSUE_NUMBER, STATE_TEXT (empty string to clear the field)
+# Non-blocking: all failures are silent no-ops
+update_board_agent_state() {
+  local ISSUE_NUMBER="$1"
+  local STATE_TEXT="$2"
+
+  if [ -z "$ISSUE_NUMBER" ]; then return 0; fi
+
+  # Read board project node ID from project.json (non-blocking — if not configured, skip)
+  BOARD_NODE_ID=$(python3 -c "
+import json, sys
+try:
+    p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    print(p.get('project', {}).get('project_board', {}).get('node_id', ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$BOARD_NODE_ID" ]; then return 0; fi
+
+  # Get board_item_id for this issue from project.json
+  ITEM_ID=$(python3 -c "
+import json, sys
+try:
+    p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+    for m in p.get('milestones', []):
+        for i in m.get('issues', []):
+            if i.get('github_number') == ${ISSUE_NUMBER}:
+                print(i.get('board_item_id', ''))
+                sys.exit(0)
+    print('')
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$ITEM_ID" ]; then return 0; fi
+
+  # Get the AI Agent State field ID from board-schema.json or project.json
+  FIELD_ID=$(python3 -c "
+import json, sys, os
+try:
+    schema_path = '${REPO_ROOT}/.mgw/board-schema.json'
+    if os.path.exists(schema_path):
+        s = json.load(open(schema_path))
+        print(s.get('fields', {}).get('ai_agent_state', {}).get('field_id', ''))
+    else:
+        p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+        fields = p.get('project', {}).get('project_board', {}).get('fields', {})
+        print(fields.get('ai_agent_state', {}).get('field_id', ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+  if [ -z "$FIELD_ID" ]; then return 0; fi
+
+  # Update the AI Agent State text field on the board item (non-blocking)
+  gh api graphql -f query='
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { text: $text }
+      }) { projectV2Item { id } }
+    }
+  ' -f projectId="$BOARD_NODE_ID" \
+    -f itemId="$ITEM_ID" \
+    -f fieldId="$FIELD_ID" \
+    -f text="$STATE_TEXT" 2>/dev/null || true
+}
+```
+
+## Stage-to-Status Mapping
+
+The Status field options correspond to pipeline_stage values:
+
+| pipeline_stage | Board Status Option |
+|----------------|-------------------|
+| `new` | New |
+| `triaged` | Triaged |
+| `needs-info` | Needs Info |
+| `needs-security-review` | Needs Security Review |
+| `discussing` | Discussing |
+| `approved` | Approved |
+| `planning` | Planning |
+| `executing` | Executing |
+| `verifying` | Verifying |
+| `pr-created` | PR Created |
+| `done` | Done |
+| `failed` | Failed |
+| `blocked` | Blocked |
+
+Option IDs for each stage are looked up at runtime from:
+1. `.mgw/board-schema.json` → `fields.status.options.<stage>` (preferred)
+2. `.mgw/project.json` → `project.project_board.fields.status.options.<stage>` (fallback)
+
+## AI Agent State Values
+
+The AI Agent State text field is set before each GSD agent spawn and cleared after PR creation:
+
+| Trigger | Value |
+|---------|-------|
+| Before gsd-planner spawn (quick route) | `"Planning"` |
+| Before gsd-executor spawn (quick route) | `"Executing"` |
+| Before gsd-verifier spawn (quick route) | `"Verifying"` |
+| Before gsd-planner spawn (milestone, phase N) | `"Planning phase N"` |
+| Before gsd-executor spawn (milestone, phase N) | `"Executing phase N"` |
+| Before gsd-verifier spawn (milestone, phase N) | `"Verifying phase N"` |
+| After PR created | `""` (clears the field) |
+
+## Data Sources
+
+| Field | Source |
+|-------|--------|
+| `BOARD_NODE_ID` | `project.json` → `project.project_board.node_id` |
+| `ITEM_ID` | `project.json` → `milestones[*].issues[*].board_item_id` (set by #73) |
+| `FIELD_ID` (status) | `board-schema.json` or `project.json` → `fields.status.field_id` |
+| `OPTION_ID` | `board-schema.json` or `project.json` → `fields.status.options.<stage>` |
+| `FIELD_ID` (agent state) | `board-schema.json` or `project.json` → `fields.ai_agent_state.field_id` |
+
+## Non-Blocking Contract
+
+Every failure case returns 0 (success) without printing to stderr. The caller is never
+aware of board sync failures. This guarantees:
+
+- Board not configured (no `node_id` in project.json) → silent no-op
+- Issue has no `board_item_id` → silent no-op (not yet added to board)
+- Status field not configured → silent no-op
+- AI Agent State field not configured → silent no-op
+- Stage has no mapped option ID → silent no-op
+- GraphQL API error → silent no-op (`|| true` suppresses exit code)
+- Network error → silent no-op
+
+## Touch Points
+
+Source or inline both utilities in any MGW command that spawns GSD agents.
+
+### update_board_status — in issue.md (triage stage transitions)
+
+After writing `pipeline_stage` to the state file in the `write_state` step:
+```bash
+# After: pipeline_stage written to .mgw/active/<issue>.json
+update_board_status $ISSUE_NUMBER "$pipeline_stage"  # non-blocking
+```
+
+Transitions in issue.md:
+- `needs-info` — validity or detail gate blocked
+- `needs-security-review` — security gate blocked
+- `triaged` — all gates passed or user override
+
+### update_board_status — in run.md (pipeline stage transitions)
+
+After each `pipeline_stage` checkpoint write to project.json and state file:
+```bash
+# After: pipeline_stage checkpoint written (state.md "Update Issue Pipeline Stage" pattern)
+update_board_status $ISSUE_NUMBER "$NEW_STAGE"  # non-blocking
+```
+
+Transitions in run.md:
+- `planning` — GSD execution begins
+- `executing` — executor agent active
+- `verifying` — verifier agent active
+- `pr-created` — PR created
+- `done` — pipeline complete
+- `blocked` — blocking comment detected in preflight_comment_check
+
+### update_board_agent_state — in run.md (around agent spawns)
+
+Called immediately before spawning each GSD agent and after PR creation:
+```bash
+# Before spawning gsd-planner
+update_board_agent_state $ISSUE_NUMBER "Planning phase ${PHASE_NUM}"
+
+# Before spawning gsd-executor
+update_board_agent_state $ISSUE_NUMBER "Executing phase ${PHASE_NUM}"
+
+# Before spawning gsd-verifier
+update_board_agent_state $ISSUE_NUMBER "Verifying phase ${PHASE_NUM}"
+
+# After PR created (clear the field)
+update_board_agent_state $ISSUE_NUMBER ""
+```
+
+## Consumers
+
+| Command | Function | When Called |
+|---------|----------|-------------|
+| issue.md | update_board_status | After writing pipeline_stage in write_state step |
+| run.md | update_board_status | After each pipeline_stage checkpoint write |
+| run.md | update_board_agent_state | Before each GSD agent spawn, and after PR creation |


### PR DESCRIPTION
## Summary
- Add `update_board_agent_state` utility to `board-sync.md` — updates the "AI Agent State" TEXT field on board items via GitHub Projects v2 GraphQL API
- Hook into `run.md` at planner/executor/verifier spawn points for both `quick` and `plan-phase` routes
- Shows current agent activity in GitHub Projects board (e.g., "Planning phase 14", "Executing phase 14")
- Non-blocking: API failures never interrupt pipeline execution

Closes #75

## Milestone Context
- **Milestone:** v2 — GitHub Projects Board Management
- **Phase:** 14 — Pipeline State Sync
- **Issue:** 5 of 9 in milestone

## Changes
- Updated: `.claude/commands/mgw/workflows/board-sync.md` — added `update_board_agent_state` function alongside existing `update_board_status`
- Updated: `.claude/commands/mgw/run.md` — inline `update_board_agent_state` definition + calls before each GSD agent spawn and clear after PR creation

## AI Agent State Update Points

| Trigger | Value |
|---------|-------|
| Before gsd-planner (quick) | `"Planning"` |
| Before gsd-executor (quick) | `"Executing"` |
| Before gsd-verifier (quick) | `"Verifying"` |
| Before gsd-planner (plan-phase, phase N) | `"Planning phase N"` |
| Before gsd-executor (plan-phase, phase N) | `"Executing phase N"` |
| Before gsd-verifier (plan-phase, phase N) | `"Verifying phase N"` |
| After PR created | `""` (clear) |

## Test Plan
- [ ] During planning, board shows "Planning phase N"
- [ ] During execution, board shows "Executing phase N"
- [ ] During verification, board shows "Verifying phase N"
- [ ] After PR creation, field is cleared to empty string
- [ ] If board not configured (no `node_id`), all calls are silent no-ops
- [ ] If issue has no `board_item_id`, all calls are silent no-ops
- [ ] If `ai_agent_state` field not in board schema, all calls are silent no-ops
- [ ] GraphQL API errors do not halt pipeline execution