### PR TITLE
feat(board): configure Table layout view for team triage planning

### DIFF
--- a/.claude/commands/mgw/board.md
+++ b/.claude/commands/mgw/board.md
@@ -1021,7 +1021,7 @@ if [ "$SUBCOMMAND" = "views" ]; then
       VIEW_KEY="kanban"
       ;;
     table)
-      VIEW_NAME="All Issues"
+      VIEW_NAME="Triage Table — Team Planning"
       VIEW_LAYOUT="TABLE_LAYOUT"
       VIEW_KEY="table"
       ;;
@@ -1140,12 +1140,31 @@ PYEOF
       echo "See docs/BOARD-SCHEMA.md for full view configuration reference."
       ;;
     table)
-      echo "Table view created. Recommended configuration in GitHub UI:"
-      echo "  1. Open: ${BOARD_URL}"
-      echo "  2. Select '${VIEW_NAME}' tab"
-      echo "  3. Sort by 'Status' ascending to surface active work at top"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo " NEXT STEP: Configure Columns in GitHub UI"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       echo ""
-      echo "See docs/BOARD-SCHEMA.md for full view configuration reference."
+      echo "Triage Table view created for team planning visibility."
+      echo "GitHub's API does not support setting table columns or sort order"
+      echo "programmatically — configure in the GitHub UI:"
+      echo ""
+      echo "  1. Open the board: ${BOARD_URL}"
+      echo "  2. Click '${VIEW_NAME}' in the view tabs"
+      echo "  3. Click the view settings (down-arrow next to view name)"
+      echo "  4. Add these columns in order:"
+      echo "       Status      (sort ascending — pipeline order)"
+      echo "       Milestone"
+      echo "       Phase"
+      echo "       GSD Route"
+      echo "       AI Agent State"
+      echo "  5. Set 'Sort by' -> 'Status' ascending"
+      echo ""
+      echo "This column order surfaces triage planning context:"
+      echo "  Status first shows pipeline position at a glance."
+      echo "  Milestone + Phase + GSD Route give scope and routing context."
+      echo "  AI Agent State shows live execution activity."
+      echo ""
+      echo "See docs/BOARD-SCHEMA.md for full column and sort configuration reference."
       ;;
     roadmap)
       echo "Roadmap view created. Recommended configuration in GitHub UI:"
@@ -1194,7 +1213,10 @@ fi  # end views subcommand
 - [ ] views: view ID stored in project.json under project.project_board.views
 - [ ] views kanban: outputs step-by-step instructions for setting Group by Status in GitHub UI
 - [ ] views kanban: lists all 13 pipeline stage columns user will see after configuring
-- [ ] views table: outputs instructions for sorting by Status
+- [ ] views table: view name is "Triage Table — Team Planning" (not generic "All Issues")
+- [ ] views table: outputs step-by-step instructions for adding triage planning columns in GitHub UI
+- [ ] views table: column order is Status, Milestone, Phase, GSD Route, AI Agent State
+- [ ] views table: outputs instructions for sorting by Status ascending
 - [ ] views roadmap: outputs instructions for date fields and milestone grouping
 - [ ] views: references docs/BOARD-SCHEMA.md for full view configuration documentation
 </success_criteria>

--- a/docs/BOARD-SCHEMA.md
+++ b/docs/BOARD-SCHEMA.md
@@ -68,7 +68,7 @@ MGW creates and configures these views using `/mgw:board views`.
 | View Name | Layout | Group By | Sort By | Purpose |
 |-----------|--------|----------|---------|---------|
 | Kanban — Pipeline Stages | BOARD_LAYOUT | Status | — | Swimlane view per pipeline stage |
-| All Issues | TABLE_LAYOUT | — | Status (asc) | Flat list of all items with all fields visible |
+| Triage Table — Team Planning | TABLE_LAYOUT | — | Status (asc) | Triage planning surface sorted by pipeline status |
 | Roadmap | ROADMAP_LAYOUT | — | Milestone | Timeline view for milestone planning |
 
 ### View Configuration Notes
@@ -81,11 +81,24 @@ MGW creates and configures these views using `/mgw:board views`.
 - GitHub's API does not support programmatic configuration of board grouping —
   use the view's settings menu in the GitHub UI after the view is created
 
-**All Issues (Table Layout)**
+**Triage Table — Team Planning (Table Layout)**
 
 - Created by `/mgw:board views table`
-- Shows all custom fields as columns
-- Sort by Status ascending to see active work at top
+- Primary planning surface for team triage and routing visibility
+- Column order for triage planning (configure in GitHub Projects UI):
+
+  | Order | Column | Purpose |
+  |-------|--------|---------|
+  | 1 | Status | Pipeline position — sort ascending for pipeline order |
+  | 2 | Milestone | Which milestone the issue belongs to |
+  | 3 | Phase | Phase number and name within the milestone |
+  | 4 | GSD Route | Execution route (quick, plan-phase, new-milestone) |
+  | 5 | AI Agent State | Live agent activity or last action |
+
+- Sort By: **Status ascending** — surfaces active work (Executing, Planning, Verifying)
+  at top, done work (Done, PR Created) at bottom
+- GitHub's API does not support setting column order or sort programmatically —
+  configure via the view settings menu in the GitHub UI after creation
 
 **Roadmap**
 
@@ -155,6 +168,11 @@ Board metadata is stored in `.mgw/project.json` under `project.project_board`:
           "view_id": "PVTV_...",
           "name": "Kanban — Pipeline Stages",
           "layout": "BOARD_LAYOUT"
+        },
+        "table": {
+          "view_id": "PVTV_...",
+          "name": "Triage Table — Team Planning",
+          "layout": "TABLE_LAYOUT"
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add mgw:board views table subcommand for triage planning view (TABLE_LAYOUT)
- Rename view from generic "All Issues" to "Triage Table — Team Planning"
- Detailed step-by-step column setup instructions: Status, Milestone, Phase, GSD Route, AI Agent State
- Update BOARD-SCHEMA.md with column order, sort configuration, and project.json storage schema

Closes #78

## Milestone Context
- **Milestone:** v2 — GitHub Projects Board Management
- **Phase:** 15 — Multi-Layout Views
- **Issue:** 8 of 9 in milestone

## Changes
- Updated: `.claude/commands/mgw/board.md` — table view name, column guidance, success criteria
- Updated: `docs/BOARD-SCHEMA.md` — triage table column order, sort config, storage example

## Note on Branch Base
This branch includes the #77 commit (Board layout kanban view) as a dependency base,
since PR #92 is not yet merged. The #77 changes are not part of this PR's diff against
`issue/77-configure-board-layout-with-pipelin` — they are included to ensure the branch
builds correctly off main.

## Test Plan
- [ ] mgw:board views table creates TABLE_LAYOUT view named "Triage Table — Team Planning"
- [ ] User receives step-by-step column configuration instructions with 5-column order
- [ ] Column order documented: Status, Milestone, Phase, GSD Route, AI Agent State
- [ ] Sort instruction: Status ascending
- [ ] BOARD-SCHEMA.md documents triage table column table and sort configuration
- [ ] BOARD-SCHEMA.md storage schema includes table view entry