### PR TITLE
feat(project): add growth analytics banner to mgw:project extend

### DIFF
--- a/commands/project.md
+++ b/commands/project.md
@@ -987,6 +987,111 @@ ${MILESTONE_HISTORY}
 GSD build history (phases and decisions already made):
 ${GSD_DIGEST:-No GSD history available.}"
 
+  # ── Growth Analytics ────────────────────────────────────────────────────────
+  # Compute milestone completion stats and issue velocity from project.json.
+  # Query open blockers from GitHub API. Spawn an AI suggester agent.
+  # Display a summary banner BEFORE asking for the extension description.
+
+  ANALYTICS=$(python3 -c "
+import json, sys
+
+p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+milestones = p.get('milestones', [])
+total_milestones = len(milestones)
+completed_milestones = sum(1 for m in milestones if m.get('gsd_state') == 'completed')
+
+# Issue velocity: avg closed issues per completed milestone
+total_closed = sum(
+    sum(1 for i in m.get('issues', []) if i.get('pipeline_stage') in ('done', 'pr-created'))
+    for m in milestones if m.get('gsd_state') == 'completed'
+)
+velocity = round(total_closed / completed_milestones, 1) if completed_milestones > 0 else 0
+
+print(f'{completed_milestones}|{total_milestones}|{velocity}|{total_closed}')
+")
+
+  COMPLETED_COUNT=$(echo "$ANALYTICS" | cut -d'|' -f1)
+  TOTAL_COUNT=$(echo "$ANALYTICS"    | cut -d'|' -f2)
+  VELOCITY=$(echo "$ANALYTICS"       | cut -d'|' -f3)
+  TOTAL_CLOSED=$(echo "$ANALYTICS"   | cut -d'|' -f4)
+
+  # Count open issues labeled blocked-by:* or with a "blocked" status
+  OPEN_BLOCKERS=$(gh api "repos/${REPO}/issues" \
+    --jq '[.[] | select(.state=="open") | select(.labels[].name | test("^blocked-by:"))] | length' \
+    2>/dev/null || echo "0")
+
+  # Spawn growth-suggester agent — reads milestone names + completed issue titles
+  # and produces natural next-area suggestions. No application code reads.
+  COMPLETED_ISSUE_TITLES=$(python3 -c "
+import json
+p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+titles = []
+for m in p.get('milestones', []):
+    if m.get('gsd_state') == 'completed':
+        for i in m.get('issues', []):
+            if i.get('pipeline_stage') in ('done', 'pr-created'):
+                titles.append(f\"  - [{m['name']}] {i['title']}\")
+print('\n'.join(titles) if titles else '  (no completed issues recorded)')
+")
+
+  MILESTONE_LIST=$(python3 -c "
+import json
+p = json.load(open('${REPO_ROOT}/.mgw/project.json'))
+for m in p.get('milestones', []):
+    state = m.get('gsd_state', 'unknown')
+    print(f\"  {m['name']} ({state})\")
+")
+
+  MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model general-purpose 2>/dev/null || echo "claude-sonnet-4-5")
+
+  SUGGESTER_OUTPUT=$(Task(
+    description="Suggest natural next milestone areas for project extension",
+    subagent_type="general-purpose",
+    prompt="
+You are a growth-suggester agent for a software project planning tool.
+
+Project: ${PROJECT_NAME}
+Repo: ${REPO}
+
+Milestones built so far:
+${MILESTONE_LIST}
+
+Completed issues (represents what has been built):
+${COMPLETED_ISSUE_TITLES}
+
+Based ONLY on the above context — what has been built and what the project does —
+suggest 3-5 natural next areas for extension milestones. Each suggestion should:
+- Build on or complement existing milestones (no overlap)
+- Be a coherent milestone-sized body of work (not a single feature)
+- Be expressed as a short label (5-10 words) with a 1-sentence rationale
+
+Output format — plain text only, one suggestion per line:
+  1. {Milestone Area Name}: {one-sentence rationale}
+  2. ...
+
+Do not add preamble, headers, or closing text. Output ONLY the numbered list.
+"
+  ))
+
+  AI_SUGGESTIONS="${SUGGESTER_OUTPUT:-  (AI suggestions unavailable)}"
+
+  # Display growth analytics banner
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo " ${PROJECT_NAME} — Growth Analytics"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  Milestones completed : ${COMPLETED_COUNT} of ${TOTAL_COUNT}"
+  echo "  Issue velocity       : ${VELOCITY} issues/milestone avg (${TOTAL_CLOSED} total closed)"
+  echo "  Open blockers        : ${OPEN_BLOCKERS}"
+  echo ""
+  echo "  AI-suggested next areas:"
+  echo "${AI_SUGGESTIONS}" | sed 's/^/  /'
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  # ── End Growth Analytics ────────────────────────────────────────────────────
+
   # Ask only for the new work — different question for extend mode
   # Ask: "What new milestones should we add to ${PROJECT_NAME}?"
   # Capture as EXTENSION_DESCRIPTION


### PR DESCRIPTION
## Summary
- Adds a growth analytics summary banner that displays before the extension description prompt in `mgw:project` extend mode
- Computes completed milestone count, total milestones, issue velocity (avg closed issues per completed milestone), and open blocker count from `project.json` and GitHub API — no application code reads
- Spawns a `general-purpose` Task agent with milestone names and completed issue titles to generate AI-suggested next milestone areas
- Banner is shown for both the `Extend` state class (all milestones complete) and the `Aligned` path when user selects extend mode

Closes #85

## Milestone Context
- **Milestone:** v2 — Team Collaboration & Lifecycle Orchestration
- **Phase:** 5 — Lifecycle Reporting & Roadmap Rendering
- **Issue:** 6 of 6 in milestone

## Changes
- `commands/project.md` — Added growth analytics block inside `gather_inputs` step's `EXTEND_MODE=true` branch, between HISTORY_CONTEXT assembly and the extension description prompt:
  - Python snippet computes completed count, total, velocity, and total closed issues from `project.json`
  - `gh api` call counts open issues with `blocked-by:*` labels
  - Python snippets extract completed issue titles and milestone list for agent context
  - `Task()` spawn for `growth-suggester` general-purpose agent producing a numbered list of 3–5 next-area suggestions
  - Echo block renders the analytics banner with box-drawing characters
- `~/.claude/commands/mgw/project.md` — Mirror of the same change applied to the runtime command file

## Test Plan
- [ ] Run `mgw:project` in a repo where all milestones are complete (Extend state) — analytics banner displays before extension description prompt
- [ ] Run `mgw:project` in an Aligned repo and choose option 2 (extend mode) — same banner appears
- [ ] Verify completed milestone count and velocity match `project.json` data
- [ ] Verify open blockers count reflects `gh api` live data
- [ ] Verify AI suggestions are printed (or fallback message shown if agent unavailable)
- [ ] Confirm extension description prompt follows the banner normally
- [ ] Confirm no application code is read — only `project.json` and GitHub API