### PR TITLE
feat(ask): add capability context — command surface, open PRs, live milestones

### DIFF
--- a/.planning/quick/4-mgw-ask-capability-context/4-PLAN.md
+++ b/.planning/quick/4-mgw-ask-capability-context/4-PLAN.md
@@ -1,0 +1,33 @@
+---
+phase: quick
+plan: 4
+type: quick
+must_haves:
+  - New step load_capability_context added between load_project_context and load_active_state in commands/ask.md
+  - Step builds COMMAND_SURFACE from commands/*.md front matter (name + description fields)
+  - Step fetches PR_CONTEXT via gh pr list --state open
+  - Step fetches MILESTONE_LIST via gh api repos/.../milestones
+  - <mgw_capabilities> block injected into Task() prompt after <recent_changes> and before <classification_rules>
+  - <context> block header updated to mention capability context and live state sources
+  - success_criteria updated with three new checklist items
+---
+
+# Plan: Issue #144 — mgw:ask missing capability context
+
+## Summary
+
+`mgw:ask` spawns a classification agent with milestone/issue context but no awareness of
+the MGW command surface, open PRs, or live GitHub milestones. This plan adds a
+`load_capability_context` step to gather that data and injects it into the agent prompt
+via a `<mgw_capabilities>` block.
+
+## Tasks
+
+### Task 1 — Update commands/ask.md
+
+| Field | Value |
+|-------|-------|
+| files | commands/ask.md |
+| action | (1) Insert new `load_capability_context` step between `load_project_context` and `load_active_state`. (2) Add `<mgw_capabilities>` block in the Task() prompt after `<recent_changes>` and before `<classification_rules>`. (3) Update `<context>` block header to mention capability context and live state. (4) Add three new items to `success_criteria`. |
+| verify | Read back the file and confirm: step exists in the correct position, `<mgw_capabilities>` block references all three variables, context block lists both new lines, success_criteria has three new items. |
+| done | All four edits applied; file parses as valid markdown with no broken XML structure. |

--- a/.planning/quick/4-mgw-ask-capability-context/4-SUMMARY.md
+++ b/.planning/quick/4-mgw-ask-capability-context/4-SUMMARY.md
@@ -1,0 +1,45 @@
+---
+phase: quick
+plan: 4
+type: quick
+issue: 144
+---
+
+# Summary: Issue #144 — mgw:ask missing capability context
+
+## What Was Done
+
+Four edits were made to `commands/ask.md`:
+
+### 1. New step: `load_capability_context` (inserted between `load_project_context` and `load_active_state`)
+
+Collects three data sources into shell variables:
+- `COMMAND_SURFACE` — iterates `commands/*.md`, extracts `name:` and `description:` front matter fields from each file
+- `PR_CONTEXT` — runs `gh pr list --state open` with JSON output to list open PRs by number, branch, and title
+- `MILESTONE_LIST` — uses `gh api repos/.../milestones` to fetch live milestone state; falls back to a "not found" message if the API is unavailable
+
+### 2. `<mgw_capabilities>` block injected into the Task() prompt
+
+Added after `<recent_changes>` and before `<classification_rules>` in `spawn_classification_agent`. The block exposes all three variables to the classification agent so it can reason about which commands exist, which PRs are in flight, and which milestones are open — even when `project.json` is absent or stale.
+
+### 3. `<context>` block header updated
+
+Added two lines documenting the new data sources:
+- `Capability context: commands/*.md front matter (name + description per command)`
+- `Live state: open PRs via gh pr list, milestones via gh api`
+
+### 4. `success_criteria` extended
+
+Added three new checklist items:
+- `Command surface index built from commands/*.md front matter`
+- `Open PRs fetched and injected into agent context`
+- `Live GitHub milestones fetched as fallback when project.json is absent`
+
+## Files Modified
+
+- `commands/ask.md`
+
+## Files Created
+
+- `.planning/quick/4-mgw-ask-capability-context/4-PLAN.md`
+- `.planning/quick/4-mgw-ask-capability-context/4-SUMMARY.md`

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -32,6 +32,8 @@ Question text: $ARGUMENTS
 
 Active issues context: .mgw/active/ (current work state)
 Project context: .mgw/project.json (milestone + all issues)
+Capability context: commands/*.md front matter (name + description per command)
+Live state: open PRs via gh pr list, milestones via gh api
 </context>
 
 <process>
@@ -107,6 +109,38 @@ for issue in m.get('issues', []):
 else
   MILESTONE_CONTEXT="No project initialized"
   ALL_ISSUES_CONTEXT=""
+fi
+```
+</step>
+
+<step name="load_capability_context">
+**Load MGW command surface, open PRs, and live milestones:**
+
+```bash
+# Extract name + description from each command's front matter
+COMMAND_SURFACE=""
+COMMANDS_DIR="${REPO_ROOT}/commands"
+for f in "${COMMANDS_DIR}"/*.md; do
+  CMD_NAME=$(grep -m1 "^name:" "$f" 2>/dev/null | sed 's/^name:[[:space:]]*//')
+  CMD_DESC=$(grep -m1 "^description:" "$f" 2>/dev/null | sed 's/^description:[[:space:]]*//')
+  if [ -n "$CMD_NAME" ]; then
+    COMMAND_SURFACE="${COMMAND_SURFACE}${CMD_NAME}: ${CMD_DESC}\n"
+  fi
+done
+
+# Fetch open PRs
+PR_CONTEXT=$(gh pr list --state open --json number,title,headRefName \
+  --jq '.[] | "#\(.number) [\(.headRefName)] \(.title)"' 2>/dev/null || echo "No open PRs")
+
+# Fetch live milestones from GitHub API
+REPO_SLUG=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+MILESTONE_LIST=""
+if [ -n "$REPO_SLUG" ]; then
+  MILESTONE_LIST=$(gh api "repos/${REPO_SLUG}/milestones" \
+    --jq '.[] | "[\(.state)] \(.title)"' 2>/dev/null || echo "")
+fi
+if [ -z "$MILESTONE_LIST" ]; then
+  MILESTONE_LIST="No milestones found (or GitHub API unavailable)"
 fi
 ```
 </step>
@@ -215,6 +249,17 @@ ${ACTIVE_STATE}
 <recent_changes>
 ${RECENT_DIFF}
 </recent_changes>
+
+<mgw_capabilities>
+## MGW Command Surface
+${COMMAND_SURFACE}
+
+## Open Pull Requests
+${PR_CONTEXT}
+
+## GitHub Milestones
+${MILESTONE_LIST}
+</mgw_capabilities>
 
 <classification_rules>
 
@@ -364,5 +409,8 @@ Consider adding it to a future milestone or filing it for backlog:
 - [ ] Actionable recommendation provided
 - [ ] Follow-up action offered (file issue, post comment, etc.)
 - [ ] Delegation boundary respected: agent reads code/state, MGW presents results
+- [ ] Command surface index built from commands/*.md front matter
+- [ ] Open PRs fetched and injected into agent context
+- [ ] Live GitHub milestones fetched as fallback when project.json is absent
 </success_criteria>
 </output>


### PR DESCRIPTION
## Summary

- Adds new `load_capability_context` step to `mgw:ask` that builds a compact command surface index from `commands/*.md` front matter, fetches open PRs via `gh pr list`, and fetches live GitHub milestones via `gh api`
- Injects all three into a `<mgw_capabilities>` block in the classification agent prompt, giving it full awareness of MGW's command surface and live project state
- No new files, no lib changes — purely additive context in a single command file

Closes #144

## Milestone Context

- **Milestone:** v3.5 — Foundation Hardening
- **Phase:** quick task — single file, no phase plan required

## Changes

**`commands/ask.md`**
- New step `load_capability_context` inserted between `load_project_context` and `load_active_state`
- `<mgw_capabilities>` block (`${COMMAND_SURFACE}`, `${PR_CONTEXT}`, `${MILESTONE_LIST}`) added to Task() prompt after `<recent_changes>`, before `<classification_rules>`
- `<context>` header updated to document the two new sources
- `success_criteria` extended with 3 new checklist items

## Test Plan

- [ ] Run `mgw:ask` with a capability question (e.g. "does mgw:run handle --dry-run?") — verify agent response references the command surface
- [ ] Run `mgw:ask` with no `.mgw/project.json` present — verify milestone list falls back to live GitHub API data instead of empty
- [ ] Run `mgw:ask` with an open PR in flight — verify agent context includes the PR
- [ ] Run `mgw:ask` with a standard issue-classification question — verify no regression in classification behavior (issue/active-state context unchanged)