### PR TITLE
docs: audit and sync README + wiki against codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ If you're already using Claude Code and GSD for development, MGW is the missing 
 | `/mgw:review <n>` | Review and classify new comments on an issue since last triage |
 | `/mgw:link <ref> <ref>` | Cross-reference issues, PRs, and branches (including milestone ↔ GSD milestone maps-to links) |
 | `/mgw:status [n]` | Project dashboard — milestone progress, issue stages, open PRs |
+| `/mgw:roadmap [--set-dates] [--post-discussion]` | Render project milestones as a roadmap table; optionally set GitHub due dates or post as a Discussion |
+| `/mgw:assign <n> [user]` | Claim or reassign an issue; resolves GitHub noreply co-author tag |
+| `/mgw:board [--sync]` | Create, configure, and sync a GitHub Projects v2 board |
 | `/mgw:sync` | Reconcile local state with GitHub; verifies GSD milestone consistency |
 | `/mgw:help` | Command reference |
 
@@ -185,9 +188,12 @@ MGW tracks pipeline state in a local `.mgw/` directory (gitignored, per-develope
     42-fix-auth.json   Issue state: triage results, pipeline stage, artifacts
   completed/           Archived after PR merge
   cross-refs.json      Bidirectional issue/PR/branch/milestone links
-  vision-draft.md      (Fresh projects) Rolling decisions from questioning loop
-  vision-brief.json    (Fresh projects) Structured Vision Brief (MoSCoW, personas, scope)
+  vision-research.json   (Fresh projects) Domain research from vision-researcher agent
+  vision-draft.md        (Fresh projects) Rolling decisions from questioning loop
+  vision-brief.json      (Fresh projects) Structured Vision Brief (MoSCoW, personas, scope)
+  vision-handoff.md      (Fresh projects) Condensed brief handed off to gsd:new-project
   alignment-report.json  (GSD-Only projects) GSD state mapped for milestone backfill
+  drift-report.json      (Diverged projects) Reconciliation table from drift-analyzer agent
 ```
 
 Pipeline stages flow: `new` → `triaged` → `planning` → `executing` → `verifying` → `pr-created` → `done` (or `failed`/`blocked`). Bugs routed to `gsd:diagnose-issues` pass through `diagnosing` before `planning`.
@@ -249,9 +255,9 @@ mgw --version
 
 # Slash commands (installed automatically by postinstall)
 ls ~/.claude/commands/mgw/
-# ask.md  board.md  help.md  init.md  issue.md  issues.md  link.md  milestone.md
-# next.md  pr.md  project.md  review.md  run.md  status.md  sync.md
-# update.md  workflows/
+# ask.md  assign.md  board.md  help.md  init.md  issue.md  issues.md  link.md
+# milestone.md  next.md  pr.md  project.md  review.md  roadmap.md  run.md
+# status.md  sync.md  update.md  workflows/
 ```
 
 Then in Claude Code:
@@ -267,7 +273,7 @@ Not all commands work via `npx`. The CLI has two tiers:
 | Tier | Commands | Requirements |
 |------|----------|--------------|
 | **CLI-only** (works with npx) | `issues`, `sync`, `link`, `help`, `--help`, `--version` | Node.js >= 18, `gh` CLI |
-| **AI-powered** (requires full install) | `run`, `init`, `project`, `milestone`, `next`, `issue`, `update`, `pr`, `ask`, `review` | Node.js >= 18, `gh` CLI, Claude Code CLI, GSD |
+| **AI-powered** (requires full install) | `run`, `init`, `project`, `milestone`, `next`, `issue`, `update`, `pr`, `ask`, `review`, `assign`, `board`, `roadmap`, `status` | Node.js >= 18, `gh` CLI, Claude Code CLI, GSD |
 
 AI-powered commands call `claude -p` under the hood and require the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/overview) to be installed and authenticated. The slash command `.md` files must also be deployed to `~/.claude/commands/mgw/` for the full pipeline to work — this happens automatically via `postinstall`. Use `npx @snipcodeit/mgw` to explore the CLI and verify your GitHub setup before committing to a full install.
 
@@ -337,12 +343,15 @@ lib/
   claude.cjs              Claude Code invocation helpers
   github.cjs              GitHub CLI wrappers (issues, PRs, milestones, Projects v2)
   gsd.cjs                 GSD integration
+  gsd-adapter.cjs         GSD route adapter (maps triage results to GSD spawn args)
   state.cjs               .mgw/ state management (migrateProjectState, resolveActiveMilestoneIndex)
   output.cjs              Logging and formatting
+  retry.cjs               Retry logic for GitHub API calls
   templates.cjs           Template system
   template-loader.cjs     Output validation (JSON Schema) + parseRoadmap()
 commands/                  Slash command source files (deployed to ~/.claude/commands/mgw/ at install time)
   ask.md                  Contextual question routing during milestone execution
+  assign.md               Claim/reassign issues; resolves GitHub noreply co-author tag
   board.md                GitHub Projects v2 board management
   help.md                 Command reference display
   init.md                 One-time repo bootstrap (state, templates, labels)
@@ -351,6 +360,7 @@ commands/                  Slash command source files (deployed to ~/.claude/com
   issue.md                Deep triage with agent analysis
   next.md                 Next unblocked issue picker (surfaces failed issues as advisory)
   review.md               Comment review and classification since last triage
+  roadmap.md              Milestone roadmap table; optional GitHub due-date setter and Discussion post
   run.md                  Autonomous pipeline orchestrator (cross-milestone enforcement)
   milestone.md            Milestone execution with dependency ordering and failed-issue recovery
   update.md               Structured GitHub comment templates
@@ -492,7 +502,7 @@ If rate-limited, wait for the reset window (usually under an hour) or reduce the
 
 ```bash
 # Remove CLI
-npm unlink mgw
+npm uninstall -g @snipcodeit/mgw
 
 # Remove slash commands
 rm -rf ~/.claude/commands/mgw/

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -139,7 +139,7 @@ The delegation boundary is the architectural rule that keeps MGW and GSD separat
 **Fresh path (Vision Collaboration Cycle):**
 1. Intake -- freeform project description
 2. Domain Expansion -- `vision-researcher` agent → `.mgw/vision-research.json`
-3. Structured Questioning -- 8 rounds (soft cap), 15 max → `.mgw/vision-draft.md`
+3. Structured Questioning -- 3-8 rounds (soft cap), 15 max (hard cap) → `.mgw/vision-draft.md`
 4. Vision Synthesis -- `vision-synthesizer` → `.mgw/vision-brief.json`
 5. Review -- accept or revise loop
 6. Condense -- `vision-condenser` → `.mgw/vision-handoff.md` → `gsd:new-project` Task spawn → `milestone_mapper`

--- a/wiki/Commands-Reference.md
+++ b/wiki/Commands-Reference.md
@@ -22,6 +22,9 @@ Complete reference for all MGW commands. Each command is available as both a Cla
 | `/mgw:sync` | Reconcile local state with GitHub | No |
 | `/mgw:ask <question>` | Route a question during work | Yes |
 | `/mgw:review <n>` | Classify new comments on an issue | Yes |
+| `/mgw:roadmap [--set-dates] [--post-discussion]` | Render milestones as roadmap; set due dates; post Discussion | No |
+| `/mgw:assign <n> [user]` | Claim or reassign an issue | Yes |
+| `/mgw:board [--sync]` | Create, configure, and sync a GitHub Projects v2 board | Yes |
 | `/mgw:help` | Command reference display | No |
 
 ---
@@ -75,7 +78,7 @@ State-aware project initializer. Detects what state your repo is in and routes t
 **Fresh path — Vision Collaboration Cycle:**
 1. **Intake** — describe your idea in plain language
 2. **Domain Expansion** — vision-researcher agent analyzes domain → `.mgw/vision-research.json`
-3. **Structured Questioning** — 3–8 rounds (soft cap), 15 max; decisions → `.mgw/vision-draft.md`
+3. **Structured Questioning** — 3–8 rounds (soft cap), 15 max (hard cap); decisions → `.mgw/vision-draft.md`
 4. **Vision Synthesis** — vision-synthesizer → `.mgw/vision-brief.json` (MoSCoW, personas, metrics)
 5. **Review** — accept or revise (loops back to step 4)
 6. **Condense + Spawn** — vision-condenser → `.mgw/vision-handoff.md` → gsd:new-project → milestone_mapper
@@ -343,6 +346,58 @@ mgw link 42 43 --quiet    # Skip GitHub comments
 mgw link 42 43 --dry-run  # Preview without creating
 mgw link 42 43 --json     # JSON output
 ```
+
+---
+
+### `/mgw:roadmap [--set-dates] [--post-discussion] [--json]`
+
+Render project milestones as a roadmap view. Read-only by default.
+
+**Usage:**
+```
+/mgw:roadmap                      # Print roadmap table
+/mgw:roadmap --set-dates          # Interactively set GitHub milestone due dates
+/mgw:roadmap --post-discussion    # Post roadmap as a GitHub Discussion
+/mgw:roadmap --json               # Machine-readable JSON output
+```
+
+**Table output includes:**
+- Milestone name, status (planned/active/done), issues done/total, progress bar, due date
+- Overall completion summary across all milestones
+
+**Notes:**
+- `--set-dates` calls `PATCH /repos/{owner}/{repo}/milestones/{number}` with `due_on`; enables Roadmap timeline layout in GitHub Projects v2
+- `--post-discussion` requires Discussions to be enabled on the repo; creates a "Roadmap" category if one exists, otherwise falls back to first available category
+- `--json` outputs machine-readable data and exits; useful for scripting
+
+---
+
+### `/mgw:assign <number> [user]`
+
+Claim an issue for a user (defaults to current user). Updates GitHub assignment and board state.
+
+**Usage:**
+```
+/mgw:assign 42         # Assign to yourself
+/mgw:assign 42 alice   # Assign to another user
+```
+
+---
+
+### `/mgw:board [--sync]`
+
+Create, configure, and sync a GitHub Projects v2 board for the repository.
+
+**Usage:**
+```
+/mgw:board          # Show board status or create board if missing
+/mgw:board --sync   # Sync all active issues to board columns
+```
+
+**What it does:**
+- Creates a GitHub Projects v2 board linked to the repo (if not already present)
+- Stores board URL and item IDs in `project.json`
+- `--sync` updates each issue's board column to match its current `pipeline_stage`
 
 ---
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -84,7 +84,10 @@ Created by `/mgw:project`. Contains the full project structure:
 
 | Field | Description |
 |-------|-------------|
-| `current_milestone` | 1-indexed pointer to the active milestone. Advanced automatically when a milestone completes. |
+| `active_gsd_milestone` | **Canonical** active milestone pointer — a GSD milestone ID string (e.g. `"v1.1"`). Always resolve this via `resolveActiveMilestoneIndex()` from `lib/state.cjs`, never read `current_milestone` directly. |
+| `current_milestone` | Legacy 1-indexed pointer kept for backward compatibility. Advanced automatically when a milestone completes. |
+| `milestones[].gsd_milestone_id` | GSD milestone ID string linking this milestone to a `.planning/` phase group (e.g. `"v1.0"`). |
+| `milestones[].gsd_state` | GSD execution state: `"active"`, `"completed"`, `"planned"`, or `null`. |
 | `pipeline_stage` (per issue) | Progress: `new` -> `triaged` -> `planning` -> `executing` -> `verifying` -> `pr-created` -> `done` (or `failed` / `blocked`) |
 | `depends_on_slugs` | Slugified issue titles for dependency resolution |
 | `phase_number` | Ordering within a milestone |

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -56,19 +56,19 @@ Try MGW without installing anything:
 
 ```bash
 # See available commands
-npx mgw --help
+npx @snipcodeit/mgw --help
 
 # List your open issues
-npx mgw issues
+npx @snipcodeit/mgw issues
 
 # Sync local state with GitHub
-npx mgw sync
+npx @snipcodeit/mgw sync
 
 # Cross-reference two issues
-npx mgw link 42 43
+npx @snipcodeit/mgw link 42 43
 ```
 
-`npx mgw` gives you the CLI subset that works without Claude Code. For the AI-powered pipeline commands (`run`, `issue`, `project`, `milestone`, etc.), do the full install.
+`npx @snipcodeit/mgw` gives you the CLI subset that works without Claude Code. For the AI-powered pipeline commands (`run`, `issue`, `project`, `milestone`, etc.), do the full install.
 
 ### Option 3: Slash Commands Only (No CLI)
 
@@ -100,8 +100,8 @@ mgw --version
 
 # Slash command verification
 ls ~/.claude/commands/mgw/
-# Expected: ask.md help.md init.md issue.md issues.md link.md
-#           milestone.md next.md pr.md project.md review.md
+# Expected: ask.md assign.md board.md help.md init.md issue.md issues.md link.md
+#           milestone.md next.md pr.md project.md review.md roadmap.md
 #           run.md status.md sync.md update.md workflows/
 ```
 
@@ -120,7 +120,7 @@ Not all commands work via `npx`. The CLI has two tiers:
 | Tier | Commands | Requirements |
 |------|----------|--------------|
 | **CLI-only** (works with npx) | `issues`, `sync`, `link`, `help`, `--help`, `--version` | Node.js >= 18, `gh` CLI |
-| **AI-powered** (requires full install) | `run`, `init`, `project`, `milestone`, `next`, `issue`, `update`, `pr` | Node.js >= 18, `gh` CLI, Claude Code CLI, GSD |
+| **AI-powered** (requires full install) | `run`, `init`, `project`, `milestone`, `next`, `issue`, `update`, `pr`, `ask`, `review`, `assign`, `board`, `roadmap`, `status` | Node.js >= 18, `gh` CLI, Claude Code CLI, GSD |
 
 AI-powered commands call `claude -p` under the hood and require the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/overview) to be installed and authenticated. The slash command `.md` files must also be deployed to `~/.claude/commands/mgw/` for the full pipeline to work.
 
@@ -229,7 +229,7 @@ Your main workspace stays on the default branch throughout. All work happens in 
 
 ```bash
 # Remove CLI
-npm unlink mgw
+npm uninstall -g @snipcodeit/mgw
 
 # Remove slash commands
 rm -rf ~/.claude/commands/mgw/

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -388,7 +388,7 @@ rm -rf .mgw/
 
 ```bash
 # Remove CLI
-npm unlink mgw
+npm uninstall -g @snipcodeit/mgw
 
 # Remove slash commands
 rm -rf ~/.claude/commands/mgw/

--- a/wiki/Workflow-Guide.md
+++ b/wiki/Workflow-Guide.md
@@ -23,7 +23,7 @@ Starting a brand new project from scratch:
 #     A vision-researcher agent analyzes your idea, identifies similar products,
 #     relevant technologies, and domain patterns. Produces .mgw/vision-research.json.
 #
-#   Stage 3 — Structured Questioning (3–8 rounds, 15 max)
+#   Stage 3 — Structured Questioning (3–8 rounds soft cap, 15 max hard cap)
 #     MGW asks targeted questions informed by the domain research.
 #     Your answers are captured as key decisions in .mgw/vision-draft.md.
 #     Type 'done' at any point to move on.


### PR DESCRIPTION
## Summary

- Parallel audit swarm (2 Explore agents) cross-referenced README.md and all wiki pages against CLAUDE.md, bin/mgw.cjs, and the commands/ directory — then applied all findings
- Three commands (`assign`, `board`, `roadmap`) were missing from every user-facing doc surface
- Several schema fields, file listings, and install instructions were stale

## Changes

**README.md**
- Add `assign`, `board`, `roadmap` to Commands table
- Add `assign`, `board`, `roadmap`, `status` to AI-powered tier table
- Fix verification output to include `assign.md` and `roadmap.md`
- Add `gsd-adapter.cjs` and `retry.cjs` to lib/ structure listing
- Add `assign.md` and `roadmap.md` to commands/ structure listing
- Add missing vision runtime files (`vision-research.json`, `vision-handoff.md`, `drift-report.json`) to State Management section
- Fix uninstall: `npm unlink mgw` → `npm uninstall -g @snipcodeit/mgw`

**wiki/Commands-Reference.md**
- Add `roadmap`, `assign`, `board` to Command Overview table
- Add full command sections for `/mgw:roadmap`, `/mgw:assign`, `/mgw:board`
- Fix Vision Cycle step 3: add `(hard cap)` label to 15-max qualifier

**wiki/Getting-Started.md**
- Fix verification list: add `assign.md`, `board.md`, `roadmap.md`
- Fix npx: `npx mgw` → `npx @snipcodeit/mgw`
- Fix AI-powered tier: add `ask`, `review`, `assign`, `board`, `roadmap`, `status`
- Fix uninstall: `npm unlink mgw` → `npm uninstall -g @snipcodeit/mgw`

**wiki/Architecture.md**
- Fix Vision Cycle step 3: `8 rounds` → `3-8 rounds (hard cap)`

**wiki/Configuration.md**
- Add `active_gsd_milestone` (canonical pointer) to project.json Key Fields
- Add `gsd_milestone_id` and `gsd_state` milestone fields with usage note

**wiki/Troubleshooting.md**
- Fix uninstall: `npm unlink mgw` → `npm uninstall -g @snipcodeit/mgw`

**wiki/Workflow-Guide.md**
- Fix Vision Cycle stage 3 caption to note soft/hard cap distinction

## Test plan

- [ ] Read through README Commands table — verify `assign`, `board`, `roadmap` entries are present and accurate
- [ ] Check README tier table — verify all slash-command-only commands appear under AI-powered
- [ ] Check `ls ~/.claude/commands/mgw/` matches verification output in README and Getting-Started.md
- [ ] Check wiki Commands-Reference — verify Overview table and command sections for `assign`, `board`, `roadmap`
- [ ] Verify uninstall commands use `npm uninstall -g @snipcodeit/mgw` in all three files
- [ ] Verify Configuration.md project.json Key Fields includes `active_gsd_milestone` with the canonical-pointer note

🤖 Generated with [Claude Code](https://claude.com/claude-code)