### PR TITLE
feat: board discovery, field hydration, and multi-machine sync

### DIFF
--- a/commands/board.md
+++ b/commands/board.md
@@ -176,6 +176,81 @@ for name, data in fields.items():
   fi
 ```
 
+**Board discovery: check GitHub for an existing board before creating a new one:**
+
+One lightweight GraphQL list call. Searches the first 20 user/org projects for a title
+containing the project name. If found, registers it in project.json and exits — no fields
+created, no board duplicated. Only runs when `BOARD_CONFIGURED = false`.
+
+```bash
+  echo "Checking GitHub for existing boards..."
+  DISCOVERED=$(node -e "
+const { findExistingBoard, getProjectFields } = require('./lib/github.cjs');
+const board = findExistingBoard('${OWNER}', '${PROJECT_NAME}');
+if (!board) { process.stdout.write(''); process.exit(0); }
+const fields = getProjectFields('${OWNER}', board.number) || {};
+console.log(JSON.stringify({ ...board, fields }));
+" 2>/dev/null || echo "")
+
+  if [ -n "$DISCOVERED" ]; then
+    DISC_NUMBER=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+    DISC_URL=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+    DISC_NODE_ID=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['nodeId'])")
+    DISC_TITLE=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+    DISC_FIELDS=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('fields', {})))")
+
+    echo "  Found existing board: #${DISC_NUMBER} \"${DISC_TITLE}\" — ${DISC_URL}"
+
+    python3 << PYEOF
+import json
+
+with open('${MGW_DIR}/project.json') as f:
+    project = json.load(f)
+
+fields = json.loads('''${DISC_FIELDS}''') if '${DISC_FIELDS}' not in ('', '{}') else {}
+
+project['project']['project_board'] = {
+    'number': int('${DISC_NUMBER}'),
+    'url': '${DISC_URL}',
+    'node_id': '${DISC_NODE_ID}',
+    'fields': fields
+}
+
+with open('${MGW_DIR}/project.json', 'w') as f:
+    json.dump(project, f, indent=2)
+
+print('project.json updated')
+PYEOF
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo " MGW ► EXISTING BOARD REGISTERED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "Board:    #${DISC_NUMBER} — ${DISC_URL}"
+    echo "Node ID:  ${DISC_NODE_ID}"
+    echo ""
+    if [ "$DISC_FIELDS" != "{}" ] && [ -n "$DISC_FIELDS" ]; then
+      echo "Fields registered:"
+      echo "$DISC_FIELDS" | python3 -c "
+import json,sys
+fields = json.load(sys.stdin)
+for name, data in fields.items():
+    ftype = data.get('type', '?')
+    print(f'  {name}: {data.get(\"field_id\",\"?\")} ({ftype})')
+" 2>/dev/null
+    else
+      echo "  (no custom fields found — run /mgw:board configure to add them)"
+    fi
+    echo ""
+    echo "To see board items: /mgw:board show"
+    exit 0
+  fi
+
+  echo "  No existing board found — creating new board..."
+  echo ""
+```
+
 **Get owner and repo node IDs (required for GraphQL mutations):**
 
 ```bash

--- a/commands/project.md
+++ b/commands/project.md
@@ -122,6 +122,60 @@ PREFIX="v1"
 @workflows/generate-template.md
 </step>
 
+<step name="discover_board">
+**Non-blocking board discovery before GitHub structure creation:**
+
+If `project.project_board.node_id` is empty, search GitHub for an existing board whose
+title contains the project name. If found, register it in project.json so the board sync
+step inside `create-github-structure.md` can use it immediately without requiring a
+separate `/mgw:board create` run.
+
+Silently skipped if board is already registered or if the API call fails.
+
+```bash
+EXISTING_NODE_ID=$(python3 -c "
+import json
+try:
+    p = json.load(open('${MGW_DIR}/project.json'))
+    print(p.get('project', {}).get('project_board', {}).get('node_id', ''))
+except:
+    print('')
+" 2>/dev/null || echo "")
+
+if [ -z "$EXISTING_NODE_ID" ]; then
+  DISCOVERED=$(node -e "
+const { findExistingBoard, getProjectFields } = require('./lib/github.cjs');
+const board = findExistingBoard('${OWNER}', '${PROJECT_NAME}');
+if (!board) { process.stdout.write(''); process.exit(0); }
+const fields = getProjectFields('${OWNER}', board.number) || {};
+console.log(JSON.stringify({ ...board, fields }));
+" 2>/dev/null || echo "")
+
+  if [ -n "$DISCOVERED" ]; then
+    python3 << PYEOF
+import json
+
+with open('${MGW_DIR}/project.json') as f:
+    project = json.load(f)
+
+d = json.loads('${DISCOVERED}')
+project['project']['project_board'] = {
+    'number': d['number'],
+    'url': d['url'],
+    'node_id': d['nodeId'],
+    'fields': d.get('fields', {})
+}
+
+with open('${MGW_DIR}/project.json', 'w') as f:
+    json.dump(project, f, indent=2)
+
+print(f"Board auto-discovered and registered: #{d['number']} — {d['url']}")
+PYEOF
+  fi
+fi
+```
+</step>
+
 <step name="create_github_structure">
 @workflows/create-github-structure.md
 </step>
@@ -138,6 +192,7 @@ PREFIX="v1"
 - [ ] Slug-to-number mapping built during Pass 1b
 - [ ] Dependency labels applied (Pass 2) — blocked-by:#N on dependent issues
 - [ ] cross-refs.json updated with dependency entries
+- [ ] Board discovery: if project_board.node_id empty before create_github_structure runs, findExistingBoard() called; if found, registered silently in project.json
 - [ ] Board sync: if board configured (PROJECT_NUMBER + BOARD_NODE_ID in project.json), each new issue added as board item
 - [ ] Board sync: Milestone, Phase, and GSD Route fields set on each board item where field IDs are available
 - [ ] Board sync: board_item_id stored per issue in project.json (null if board sync skipped or failed)

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -16,6 +16,11 @@ if the GitHub issue is still open, if linked PRs were merged/closed, and if trac
 branches still exist. Moves completed items to .mgw/completed/, cleans up branches
 and lingering worktrees, flags inconsistencies.
 
+Also pulls board state to reconstruct missing local state files — enabling multi-machine
+workflows. On a fresh machine with no .mgw/active/ files, sync reads the GitHub Projects
+v2 board's Status field and rebuilds local state for every in-progress issue, so work
+can continue without re-triaging from scratch.
+
 Run periodically or when starting a new session to get a clean view.
 </objective>
 
@@ -27,6 +32,321 @@ Run periodically or when starting a new session to get a clean view.
 </execution_context>
 
 <process>
+
+<step name="pull_board_state">
+**Pull board state to reconstruct missing local .mgw/active/ files.**
+
+This step runs first — before scan_active — so that any issues the board knows about
+but this machine doesn't will be present by the time check_each runs. This is the
+multi-machine sync mechanism: board is the distributed source of truth, .mgw/active/
+is the local cache that sync rebuilds from it.
+
+Two sub-operations, both non-blocking:
+1. **Board discovery** — if project_board.node_id is missing, find and register it.
+2. **Board pull** — fetch all board items, reconstruct .mgw/active/ for any issue not
+   present locally, detect stage drift for issues that exist on both sides.
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+MGW_DIR="${REPO_ROOT}/.mgw"
+OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null)
+ACTIVE_DIR="${MGW_DIR}/active"
+mkdir -p "$ACTIVE_DIR"
+
+BOARD_NODE_ID=$(python3 -c "
+import json
+try:
+    p = json.load(open('${MGW_DIR}/project.json'))
+    print(p.get('project', {}).get('project_board', {}).get('node_id', ''))
+except: print('')
+" 2>/dev/null || echo "")
+
+BOARD_DISCOVERED=""
+BOARD_PULL_CREATED=0
+BOARD_PULL_DRIFT="[]"
+BOARD_PULL_ERRORS="[]"
+
+# Sub-operation 1: board discovery
+if [ -z "$BOARD_NODE_ID" ] && [ -f "${MGW_DIR}/project.json" ]; then
+  PROJECT_NAME=$(python3 -c "
+import json
+try:
+    p = json.load(open('${MGW_DIR}/project.json'))
+    print(p.get('project', {}).get('name', ''))
+except: print('')
+" 2>/dev/null || echo "")
+
+  if [ -n "$PROJECT_NAME" ]; then
+    DISCOVERED=$(node -e "
+const { findExistingBoard, getProjectFields } = require('./lib/github.cjs');
+const board = findExistingBoard('${OWNER}', '${PROJECT_NAME}');
+if (!board) { process.stdout.write(''); process.exit(0); }
+const fields = getProjectFields('${OWNER}', board.number) || {};
+console.log(JSON.stringify({ ...board, fields }));
+" 2>/dev/null || echo "")
+
+    if [ -n "$DISCOVERED" ]; then
+      python3 -c "
+import json
+with open('${MGW_DIR}/project.json') as f:
+    project = json.load(f)
+d = json.loads('${DISCOVERED}')
+project['project']['project_board'] = {
+    'number': d['number'], 'url': d['url'],
+    'node_id': d['nodeId'], 'fields': d.get('fields', {})
+}
+with open('${MGW_DIR}/project.json', 'w') as f:
+    json.dump(project, f, indent=2)
+" 2>/dev/null
+      BOARD_NODE_ID=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['nodeId'])" 2>/dev/null)
+      DISC_NUMBER=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])" 2>/dev/null)
+      DISC_URL=$(echo "$DISCOVERED" | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])" 2>/dev/null)
+      BOARD_DISCOVERED="#${DISC_NUMBER} — ${DISC_URL}"
+    fi
+  fi
+fi
+
+# Sub-operation 2: board pull
+if [ -n "$BOARD_NODE_ID" ]; then
+  echo "Pulling board state from GitHub..."
+
+  BOARD_ITEMS=$(gh api graphql -f query='
+    query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100) {
+            nodes {
+              id
+              content {
+                ... on Issue { number title url }
+              }
+              fieldValues(first: 10) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2SingleSelectField { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ' -f projectId="$BOARD_NODE_ID" \
+    --jq '.data.node.items.nodes' 2>/dev/null || echo "[]")
+
+  # One Python call handles: map board items, detect missing local files,
+  # reconstruct state from GitHub issue data, detect drift on existing files.
+  PULL_RESULT=$(echo "$BOARD_ITEMS" | ACTIVE_DIR="$ACTIVE_DIR" MGW_DIR="$MGW_DIR" python3 << 'PYEOF'
+import json, sys, os, subprocess, re
+
+ACTIVE_DIR = os.environ['ACTIVE_DIR']
+GSD_TOOLS = os.path.expanduser('~/.claude/get-shit-done/bin/gsd-tools.cjs')
+
+STATUS_TO_STAGE = {
+    'New': 'new', 'Triaged': 'triaged',
+    'Needs Info': 'needs-info', 'Needs Security Review': 'needs-security-review',
+    'Discussing': 'discussing', 'Approved': 'approved',
+    'Planning': 'planning', 'Executing': 'executing',
+    'Verifying': 'verifying', 'PR Created': 'pr-created',
+    'Done': 'done', 'Failed': 'failed', 'Blocked': 'blocked'
+}
+
+nodes = json.load(sys.stdin)
+created = []
+drift = []
+errors = []
+
+for node in nodes:
+    content = node.get('content', {})
+    num = content.get('number')
+    if num is None:
+        continue
+
+    status_label = ''
+    route_label = ''
+    for fv in node.get('fieldValues', {}).get('nodes', []):
+        fname = fv.get('field', {}).get('name', '')
+        if fname == 'Status':
+            status_label = fv.get('name', '')
+        elif fname == 'GSD Route':
+            route_label = fv.get('name', '')
+
+    board_stage = STATUS_TO_STAGE.get(status_label, 'new')
+
+    # Done items belong in completed/, not active/ — skip
+    if board_stage == 'done':
+        continue
+
+    # Check for existing local active file
+    existing = None
+    for fname in os.listdir(ACTIVE_DIR):
+        if fname.startswith(f'{num}-') and fname.endswith('.json'):
+            existing = os.path.join(ACTIVE_DIR, fname)
+            break
+
+    if existing is None:
+        # No local file — reconstruct from GitHub issue data
+        try:
+            r = subprocess.run(
+                ['gh', 'issue', 'view', str(num),
+                 '--json', 'number,title,url,labels,assignees'],
+                capture_output=True, text=True
+            )
+            issue = json.loads(r.stdout)
+        except Exception as e:
+            errors.append({'number': num, 'error': str(e)})
+            continue
+
+        title = issue.get('title', content.get('title', ''))
+
+        try:
+            slug = subprocess.run(
+                ['node', GSD_TOOLS, 'generate-slug', title, '--raw'],
+                capture_output=True, text=True
+            ).stdout.strip()[:40]
+        except:
+            slug = re.sub(r'[^a-z0-9]+', '-', title.lower()).strip('-')[:40]
+
+        try:
+            ts = subprocess.run(
+                ['node', GSD_TOOLS, 'current-timestamp', '--raw'],
+                capture_output=True, text=True
+            ).stdout.strip()
+        except:
+            from datetime import datetime
+            ts = datetime.utcnow().isoformat() + 'Z'
+
+        labels = [l.get('name', '') if isinstance(l, dict) else str(l)
+                  for l in issue.get('labels', [])]
+        assignees = issue.get('assignees', [])
+        assignee = assignees[0].get('login') if assignees else None
+
+        state = {
+            'issue': {
+                'number': num,
+                'title': title,
+                'url': issue.get('url', content.get('url', '')),
+                'labels': labels,
+                'assignee': assignee
+            },
+            'triage': {
+                'scope': {'files': 0, 'systems': []},
+                'validity': 'confirmed',
+                'security_notes': '',
+                'conflicts': [],
+                'last_comment_count': 0,
+                'last_comment_at': None,
+                'gate_result': {
+                    'status': 'passed',
+                    'blockers': [],
+                    'warnings': [f'Reconstructed from board state by mgw:sync — {ts}'],
+                    'missing_fields': []
+                }
+            },
+            'gsd_route': route_label or None,
+            'gsd_artifacts': {'type': None, 'path': None},
+            'pipeline_stage': board_stage,
+            'reconstructed_from_board': True,
+            'comments_posted': [],
+            'linked_pr': None,
+            'linked_issues': [],
+            'linked_branches': []
+        }
+
+        state_path = os.path.join(ACTIVE_DIR, f'{num}-{slug}.json')
+        with open(state_path, 'w') as f:
+            json.dump(state, f, indent=2)
+
+        created.append({'number': num, 'title': title, 'stage': board_stage})
+
+    else:
+        # Local file exists — detect stage drift
+        try:
+            local = json.load(open(existing))
+            local_stage = local.get('pipeline_stage', 'new')
+            if local_stage != board_stage:
+                drift.append({
+                    'number': num,
+                    'title': content.get('title', ''),
+                    'local': local_stage,
+                    'board': board_stage
+                })
+        except:
+            pass
+
+print(json.dumps({'created': created, 'drift': drift, 'errors': errors}))
+PYEOF
+)
+
+  BOARD_PULL_CREATED=$(echo "$PULL_RESULT" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('created', [])))" 2>/dev/null || echo "0")
+  BOARD_PULL_DRIFT=$(echo "$PULL_RESULT" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('drift', [])))" 2>/dev/null || echo "[]")
+  BOARD_PULL_ERRORS=$(echo "$PULL_RESULT" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('errors', [])))" 2>/dev/null || echo "[]")
+
+  if [ "$BOARD_PULL_CREATED" -gt 0 ]; then
+    echo "  Reconstructed ${BOARD_PULL_CREATED} issue(s) from board state"
+    echo "$PULL_RESULT" | python3 -c "
+import json, sys
+for item in json.load(sys.stdin).get('created', []):
+    print(f'  ✓ #{item[\"number\"]} ({item[\"stage\"]}): {item[\"title\"][:60]}')
+" 2>/dev/null
+  fi
+
+  # Offer drift resolution if any issues have mismatched stages
+  DRIFT_COUNT=$(echo "$BOARD_PULL_DRIFT" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+  if [ "$DRIFT_COUNT" -gt 0 ]; then
+    echo ""
+    echo "Stage drift detected (board vs local):"
+    echo "$BOARD_PULL_DRIFT" | python3 -c "
+import json, sys
+for d in json.load(sys.stdin):
+    print(f'  #{d[\"number\"]} {d[\"title\"][:45]}: local={d[\"local\"]} board={d[\"board\"]}')
+" 2>/dev/null
+    echo ""
+
+    AskUserQuestion(
+      header: "Stage Drift",
+      question: "Board and local state disagree on pipeline stage for ${DRIFT_COUNT} issue(s). How should we resolve?",
+      options: [
+        { label: "Pull from board", description: "Update all local files to match board stages (board is source of truth)" },
+        { label: "Keep local",      description: "Leave local stages as-is — board will be updated next time pipeline runs" },
+        { label: "Skip",            description: "Ignore drift for now — flag in report only" }
+      ]
+    )
+
+    if [ "$USER_CHOICE" = "Pull from board" ]; then
+      echo "$BOARD_PULL_DRIFT" | python3 -c "
+import json, sys, os
+
+drift = json.load(sys.stdin)
+active_dir = '${ACTIVE_DIR}'
+
+for d in drift:
+    num = d['number']
+    board_stage = d['board']
+    for fname in os.listdir(active_dir):
+        if fname.startswith(f'{num}-') and fname.endswith('.json'):
+            path = os.path.join(active_dir, fname)
+            state = json.load(open(path))
+            state['pipeline_stage'] = board_stage
+            with open(path, 'w') as f:
+                json.dump(state, f, indent=2)
+            print(f'  Updated #{num}: {d[\"local\"]} → {board_stage}')
+            break
+" 2>/dev/null
+      BOARD_PULL_DRIFT="[]"  # Resolved
+    fi
+  fi
+fi
+```
+
+**Note:** `reconstructed_from_board: true` is set on any state file created this way.
+Downstream commands (`/mgw:run`, `/mgw:issue`) will see this flag and know the state was
+rebuilt from board data — triage results and GSD artifacts will need to be re-run if the
+issue advances to `planning` or beyond.
+</step>
 
 <step name="scan_active">
 **Scan all active issue states:**
@@ -214,11 +534,13 @@ git push origin --delete ${BRANCH_NAME} 2>/dev/null
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Active:    ${active_count} issues in progress
+Pulled:    ${BOARD_PULL_CREATED} reconstructed from board  (0 if board not configured)
 Completed: ${completed_count} archived
 Stale:     ${stale_count} need attention
 Orphaned:  ${orphaned_count} need attention
 Comments:  ${comment_drift_count} issues with unreviewed comments
 Branches:  ${deleted_count} cleaned up
+${BOARD_DISCOVERED ? 'Board:     discovered + registered ' + BOARD_DISCOVERED : ''}
 ${HEALTH ? 'GSD Health: ' + HEALTH.status : ''}
 
 ${details_for_each_non_active_item}
@@ -231,7 +553,16 @@ ${gsd_milestone_consistency ? 'GSD Milestone Links:\n' + gsd_milestone_consisten
 </process>
 
 <success_criteria>
-- [ ] All .mgw/active/ files scanned
+- [ ] pull_board_state runs before scan_active
+- [ ] Board discovery: if project_board.node_id empty, findExistingBoard() + getProjectFields() called; if found, registered in project.json
+- [ ] Board pull: all board items fetched in one GraphQL call; issues with no local .mgw/active/ file are reconstructed from GitHub issue data + board Status
+- [ ] Reconstructed files have reconstructed_from_board:true, pipeline_stage from board Status, gsd_route from board GSD Route field
+- [ ] "Done" board items are skipped (not written to active/)
+- [ ] Stage drift detected and reported: local pipeline_stage differs from board Status
+- [ ] Drift resolution offered: pull from board / keep local / skip
+- [ ] Board pull errors (failed gh issue view calls) are collected and shown in report, never abort sync
+- [ ] BOARD_PULL_CREATED count shown in sync report
+- [ ] All .mgw/active/ files scanned (including any reconstructed by pull_board_state)
 - [ ] GitHub state checked for each issue, PR, branch
 - [ ] Comment delta checked for each active issue
 - [ ] GSD milestone consistency checked for all maps-to links

--- a/lib/github.cjs
+++ b/lib/github.cjs
@@ -126,6 +126,130 @@ function createRelease(repo, tag, title, opts) {
 }
 
 /**
+ * Find an existing GitHub Projects v2 board by owner and title substring.
+ * Searches the first 20 user projects, falls back to org projects.
+ * Non-blocking: returns null if API call fails.
+ * @param {string} owner - GitHub user or org login
+ * @param {string} titlePattern - Substring to match (case-insensitive)
+ * @returns {{ number: number, url: string, nodeId: string, title: string } | null}
+ */
+function findExistingBoard(owner, titlePattern) {
+  const pattern = titlePattern.toLowerCase();
+
+  // Try user projects first
+  try {
+    const raw = run(
+      `gh api graphql -f query='query($login: String!) { user(login: $login) { projectsV2(first: 20) { nodes { id number url title } } } }' -f login=${JSON.stringify(owner)} --jq '.data.user.projectsV2.nodes'`
+    );
+    const nodes = JSON.parse(raw);
+    const match = nodes.find(n => n.title.toLowerCase().includes(pattern));
+    if (match) return { number: match.number, url: match.url, nodeId: match.id, title: match.title };
+  } catch (_) {}
+
+  // Fall back to org projects
+  try {
+    const raw = run(
+      `gh api graphql -f query='query($login: String!) { organization(login: $login) { projectsV2(first: 20) { nodes { id number url title } } } }' -f login=${JSON.stringify(owner)} --jq '.data.organization.projectsV2.nodes'`
+    );
+    const nodes = JSON.parse(raw);
+    const match = nodes.find(n => n.title.toLowerCase().includes(pattern));
+    if (match) return { number: match.number, url: match.url, nodeId: match.id, title: match.title };
+  } catch (_) {}
+
+  return null;
+}
+
+/**
+ * Fetch all custom fields from an existing GitHub Projects v2 board.
+ * Returns a fields object matching the project.project_board.fields schema.
+ * Non-blocking: returns null if the API call fails or no recognized fields exist.
+ * @param {string} owner - GitHub user or org login
+ * @param {number} projectNumber - Project board number
+ * @returns {object|null} Fields object keyed by: status, ai_agent_state, phase, gsd_route, milestone
+ */
+function getProjectFields(owner, projectNumber) {
+  const query = `'query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } ... on ProjectV2Field { id name dataType } } } } } }'`;
+  const orgQuery = `'query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } ... on ProjectV2Field { id name dataType } } } } } }'`;
+
+  let raw;
+  try {
+    raw = run(`gh api graphql -f query=${query} -f login=${JSON.stringify(owner)} -F number=${projectNumber} --jq '.data.user.projectV2.fields.nodes'`);
+  } catch (_) {
+    try {
+      raw = run(`gh api graphql -f query=${orgQuery} -f login=${JSON.stringify(owner)} -F number=${projectNumber} --jq '.data.organization.projectV2.fields.nodes'`);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  const nodes = JSON.parse(raw);
+  const fields = {};
+
+  // Status (SINGLE_SELECT — maps pipeline stages to option IDs)
+  const statusNode = nodes.find(n => n.name === 'Status' && n.options);
+  if (statusNode) {
+    const stageMap = {
+      'new': 'New', 'triaged': 'Triaged', 'needs-info': 'Needs Info',
+      'needs-security-review': 'Needs Security Review', 'discussing': 'Discussing',
+      'approved': 'Approved', 'planning': 'Planning', 'executing': 'Executing',
+      'verifying': 'Verifying', 'pr-created': 'PR Created', 'done': 'Done',
+      'failed': 'Failed', 'blocked': 'Blocked'
+    };
+    const nameToId = Object.fromEntries(statusNode.options.map(o => [o.name, o.id]));
+    fields.status = {
+      field_id: statusNode.id,
+      field_name: 'Status',
+      type: 'SINGLE_SELECT',
+      options: Object.fromEntries(
+        Object.entries(stageMap).map(([stage, label]) => [stage, nameToId[label] || ''])
+      )
+    };
+  }
+
+  // AI Agent State (TEXT)
+  const aiNode = nodes.find(n => n.name === 'AI Agent State' && !n.options);
+  if (aiNode) {
+    fields.ai_agent_state = { field_id: aiNode.id, field_name: 'AI Agent State', type: 'TEXT' };
+  }
+
+  // Phase (TEXT)
+  const phaseNode = nodes.find(n => n.name === 'Phase' && !n.options);
+  if (phaseNode) {
+    fields.phase = { field_id: phaseNode.id, field_name: 'Phase', type: 'TEXT' };
+  }
+
+  // GSD Route (SINGLE_SELECT)
+  const routeNode = nodes.find(n => n.name === 'GSD Route' && n.options);
+  if (routeNode) {
+    const routeMap = {
+      'gsd:quick': 'quick', 'gsd:quick --full': 'quick --full',
+      'gsd:plan-phase': 'plan-phase', 'gsd:new-milestone': 'new-milestone'
+    };
+    const nameToId = Object.fromEntries(routeNode.options.map(o => [o.name, o.id]));
+    fields.gsd_route = {
+      field_id: routeNode.id,
+      field_name: 'GSD Route',
+      type: 'SINGLE_SELECT',
+      options: Object.fromEntries(
+        Object.entries(routeMap).map(([route, label]) => [route, nameToId[label] || ''])
+      )
+    };
+  }
+
+  // Milestone (native MILESTONE type or TEXT fallback)
+  const milestoneNode = nodes.find(n => n.name === 'Milestone');
+  if (milestoneNode) {
+    fields.milestone = {
+      field_id: milestoneNode.id,
+      field_name: 'Milestone',
+      type: milestoneNode.dataType || (milestoneNode.options ? 'SINGLE_SELECT' : 'TEXT')
+    };
+  }
+
+  return Object.keys(fields).length > 0 ? fields : null;
+}
+
+/**
  * Create a GitHub Projects v2 board.
  * @param {string} owner - GitHub org or user (e.g. "snipcodeit")
  * @param {string} title - Project board title
@@ -266,6 +390,8 @@ module.exports = {
   getRateLimit,
   closeMilestone,
   createRelease,
+  findExistingBoard,
+  getProjectFields,
   createProject,
   addItemToProject,
   postMilestoneStartAnnouncement


### PR DESCRIPTION
## Summary

- **`lib/github.cjs`**: Added `findExistingBoard()` and `getProjectFields()` — lightweight GraphQL wrappers that discover an existing GitHub Projects v2 board by owner + title substring and hydrate all custom field schemas (Status options mapped to pipeline stages, GSD Route options, Phase, Milestone, AI Agent State)
- **`commands/board.md`**: Wired board discovery as the first check in `board create` — if a matching board exists on GitHub but isn't registered in `project.json`, it's registered automatically instead of creating a duplicate
- **`commands/project.md`**: Added `discover_board` step before `create_github_structure` — non-blocking pre-flight that registers an existing board silently so board sync in the structure creation step works on first run
- **`commands/sync.md`**: Added `pull_board_state` step as the first operation in sync — pulls all board items via a single GraphQL query and reconstructs missing `.mgw/active/` state files from the board's Status field; solves the multi-machine re-triage problem where switching dev environments required re-triaging every issue

## Problem Solved

Previously, MGW only tracked issues as "active" if they had a corresponding `.mgw/active/` state file on the current machine. Switching to a different computer or environment resulted in all in-progress issues appearing as `new` again, requiring repeated triage. The board held the true pipeline state but MGW never read from it.

Now `mgw:sync` uses the board as the distributed source of truth: on a fresh machine, it discovers the board, pulls all in-progress items, reconstructs local state files from the board's Status field, and the pipeline can continue without re-triage.

## Test plan

- [ ] Run `/mgw:board create` on a repo with an existing board — should register the board instead of creating a new one
- [ ] Run `/mgw:project` on a repo with an existing board — `discover_board` step should register silently
- [ ] Run `/mgw:sync` on a fresh `.mgw/` directory with an active board — should reconstruct `.mgw/active/` files for all in-progress issues
- [ ] Verify `reconstructed_from_board: true` flag is set on reconstructed state files
- [ ] Verify stage drift detection works when local `pipeline_stage` ≠ board Status
- [ ] Smoke test `findExistingBoard` and `getProjectFields` in `lib/github.cjs` with `node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)