### PR TITLE
feat(cli): add per-stage spinners to mgw:run pipeline steps

### DIFF
--- a/bin/mgw.cjs
+++ b/bin/mgw.cjs
@@ -25,6 +25,7 @@ const { log, error, formatJson, verbose } = require('../lib/output.cjs');
 const { getActiveDir, getCompletedDir, getMgwDir } = require('../lib/state.cjs');
 const { getIssue, listIssues } = require('../lib/github.cjs');
 const { createIssuesBrowser } = require('../lib/tui/index.cjs');
+const { createSpinner } = require('../lib/spinner.cjs');
 
 const pkg = require('../package.json');
 
@@ -49,6 +50,21 @@ program
 // ---------------------------------------------------------------------------
 
 /**
+ * Pipeline stage labels shown as spinners before handing off to claude.
+ * Used by runAiCommand when a stageLabel is provided.
+ */
+const STAGE_LABELS = {
+  run: 'pipeline',
+  init: 'init',
+  project: 'project',
+  milestone: 'milestone',
+  issue: 'triage',
+  pr: 'create-pr',
+  update: 'update',
+  next: 'next',
+};
+
+/**
  * @param {string} commandName - Name of the command (filename without .md)
  * @param {string} userPrompt - Prompt text to pass to claude
  * @param {object} opts - Merged options from this.optsWithGlobals()
@@ -56,13 +72,51 @@ program
 async function runAiCommand(commandName, userPrompt, opts) {
   assertClaudeAvailable();
   const cmdFile = path.join(getCommandsDir(), `${commandName}.md`);
-  const result = await invokeClaude(cmdFile, userPrompt, {
-    model: opts.model,
-    quiet: opts.quiet,
-    dryRun: opts.dryRun,
-    json: opts.json,
-  });
-  process.exitCode = result.exitCode;
+  const stageLabel = STAGE_LABELS[commandName] || commandName;
+
+  if (opts.quiet) {
+    // Quiet mode: buffer claude output and show a spinner while it runs.
+    // The spinner gives real-time feedback when output is suppressed.
+    const spinner = createSpinner(`mgw:${stageLabel}`);
+    spinner.start();
+    let result;
+    try {
+      result = await invokeClaude(cmdFile, userPrompt, {
+        model: opts.model,
+        quiet: true,
+        dryRun: opts.dryRun,
+        json: opts.json,
+      });
+    } catch (err) {
+      spinner.fail(`${stageLabel} failed`);
+      throw err;
+    }
+    if (result.exitCode === 0) {
+      spinner.succeed(`${stageLabel} complete`);
+    } else {
+      spinner.fail(`${stageLabel} failed (exit ${result.exitCode})`);
+    }
+    if (result.output) {
+      process.stdout.write(result.output);
+    }
+    process.exitCode = result.exitCode;
+  } else {
+    // Streaming mode: show a brief stage announcement, then hand off to claude.
+    // Claude streams its own output — no spinner during streaming to avoid conflicts.
+    const spinner = createSpinner(`mgw:${stageLabel}`);
+    spinner.start();
+    // Give a brief visual indication before handing TTY to claude's streaming output
+    await new Promise(r => setTimeout(r, 80));
+    spinner.stop();
+
+    const result = await invokeClaude(cmdFile, userPrompt, {
+      model: opts.model,
+      quiet: false,
+      dryRun: opts.dryRun,
+      json: opts.json,
+    });
+    process.exitCode = result.exitCode;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +124,15 @@ async function runAiCommand(commandName, userPrompt, opts) {
 // Note: All .action() handlers use `function` (not arrow) so `this` is bound
 // to the Command instance, enabling this.optsWithGlobals() for global flags.
 // ---------------------------------------------------------------------------
+
+/** Pipeline stage sequence shown as a progress header for `mgw run` */
+const RUN_PIPELINE_STAGES = [
+  'validate',
+  'triage',
+  'create-worktree',
+  'execute-gsd',
+  'create-pr',
+];
 
 // run <issue-number>
 program
@@ -79,6 +142,15 @@ program
   .option('--auto', 'phase chaining: discuss -> plan -> execute')
   .action(async function(issueNumber) {
     const opts = this.optsWithGlobals();
+    // Print pipeline stage overview before launching
+    if (!opts.json) {
+      const { USE_COLOR, COLORS } = require('../lib/output.cjs');
+      const dim = USE_COLOR ? COLORS.dim : '';
+      const reset = USE_COLOR ? COLORS.reset : '';
+      const bold = USE_COLOR ? COLORS.bold : '';
+      const stages = RUN_PIPELINE_STAGES.join(` ${dim}→${reset} `);
+      process.stdout.write(`${bold}mgw:run${reset} #${issueNumber}  ${dim}${stages}${reset}\n`);
+    }
     await runAiCommand('run', issueNumber, opts);
   });
 

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -17,5 +17,6 @@ module.exports = {
   ...require('./output.cjs'),
   ...require('./claude.cjs'),
   ...require('./retry.cjs'),
+  ...require('./spinner.cjs'),
   ...require('./tui/index.cjs')
 };

--- a/lib/spinner.cjs
+++ b/lib/spinner.cjs
@@ -1,0 +1,168 @@
+'use strict';
+
+/**
+ * lib/spinner.cjs — Per-stage spinner for mgw:run pipeline steps
+ *
+ * Provides a simple TTY spinner that shows the active pipeline stage
+ * with elapsed time. Falls back to plain log lines in non-TTY/CI environments.
+ *
+ * Respects the same TTY/CI/NO_COLOR detection as lib/output.cjs.
+ */
+
+const { IS_TTY, IS_CI, USE_COLOR, COLORS } = require('./output.cjs');
+
+/** Spinner frames for animation */
+const FRAMES = ['|', '/', '-', '\\'];
+
+/** Whether the terminal supports live spinner updates */
+const SUPPORTS_SPINNER = IS_TTY && !IS_CI;
+
+/**
+ * Create a new pipeline stage spinner.
+ *
+ * Usage:
+ *   const s = createSpinner('validate');
+ *   s.start();
+ *   // ... do work ...
+ *   s.succeed('Validated — issue #120 triaged');
+ *
+ * @returns {object} Spinner instance with start/succeed/fail/stop methods
+ */
+function createSpinner(stage) {
+  let frameIndex = 0;
+  let intervalId = null;
+  let startTime = null;
+  let lastLineLength = 0;
+
+  /**
+   * Clear the current spinner line (move cursor to start, erase line).
+   */
+  function clearLine() {
+    if (!SUPPORTS_SPINNER) return;
+    process.stdout.write('\r' + ' '.repeat(lastLineLength) + '\r');
+  }
+
+  /**
+   * Write a spinner frame with stage label and elapsed time.
+   */
+  function render() {
+    const frame = FRAMES[frameIndex % FRAMES.length];
+    frameIndex++;
+
+    const elapsed = startTime ? Math.floor((Date.now() - startTime) / 1000) : 0;
+    const elapsedStr = elapsed > 0 ? ` (${elapsed}s)` : '';
+
+    let line;
+    if (USE_COLOR) {
+      line = `${COLORS.cyan}${frame}${COLORS.reset} ${COLORS.bold}${stage}${COLORS.reset}${COLORS.dim}${elapsedStr}${COLORS.reset}`;
+    } else {
+      line = `${frame} ${stage}${elapsedStr}`;
+    }
+
+    if (SUPPORTS_SPINNER) {
+      clearLine();
+      process.stdout.write(line);
+      // Track plain text length for clearing (strip ANSI codes approximation)
+      lastLineLength = `${frame} ${stage}${elapsedStr}`.length;
+    }
+  }
+
+  /**
+   * Start the spinner animation.
+   * In non-TTY mode, prints a simple "starting stage" line.
+   * @param {string} [label] - Optional override for the stage label
+   */
+  function start(label) {
+    if (label) stage = label;
+    startTime = Date.now();
+
+    if (SUPPORTS_SPINNER) {
+      render();
+      intervalId = setInterval(render, 100);
+    } else {
+      // Non-TTY: plain log line
+      process.stdout.write(`[mgw] ${stage}...\n`);
+    }
+  }
+
+  /**
+   * Stop the spinner and print a success line.
+   * @param {string} [message] - Optional completion message (defaults to stage name)
+   */
+  function succeed(message) {
+    _stop();
+    const text = message || stage;
+    if (USE_COLOR) {
+      process.stdout.write(`${COLORS.green}✓${COLORS.reset} ${text}\n`);
+    } else {
+      process.stdout.write(`[done] ${text}\n`);
+    }
+  }
+
+  /**
+   * Stop the spinner and print a failure line.
+   * @param {string} [message] - Optional failure message (defaults to stage name)
+   */
+  function fail(message) {
+    _stop();
+    const text = message || stage;
+    if (USE_COLOR) {
+      process.stdout.write(`${COLORS.red}✗${COLORS.reset} ${text}\n`);
+    } else {
+      process.stdout.write(`[fail] ${text}\n`);
+    }
+  }
+
+  /**
+   * Stop the spinner without printing a result line.
+   */
+  function stop() {
+    _stop();
+  }
+
+  /**
+   * Internal: clear interval and erase spinner line.
+   */
+  function _stop() {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+    clearLine();
+  }
+
+  return { start, succeed, fail, stop };
+}
+
+/**
+ * Wrap an async function call with a spinner for a named pipeline stage.
+ *
+ * Shows a spinner while fn() is running, then prints succeed/fail based
+ * on whether fn() resolves or rejects.
+ *
+ * @param {string} stage - Human-readable stage name (e.g. 'validate', 'execute-gsd')
+ * @param {Function} fn - Async function to run while spinner is active
+ * @param {object} [opts]
+ * @param {string} [opts.successMessage] - Message shown on success (default: stage)
+ * @param {string} [opts.failMessage] - Message shown on failure (default: stage + ' failed')
+ * @returns {Promise<*>} Resolves with fn()'s return value, rejects if fn() throws
+ */
+async function withSpinner(stage, fn, opts) {
+  const o = opts || {};
+  const spinner = createSpinner(stage);
+  spinner.start();
+  try {
+    const result = await fn();
+    spinner.succeed(o.successMessage || stage);
+    return result;
+  } catch (err) {
+    spinner.fail(o.failMessage || `${stage} failed`);
+    throw err;
+  }
+}
+
+module.exports = {
+  createSpinner,
+  withSpinner,
+  SUPPORTS_SPINNER
+};

--- a/test/mgw.test.cjs
+++ b/test/mgw.test.cjs
@@ -49,6 +49,7 @@ describe('mgw', () => {
       'claude.cjs',
       'template-loader.cjs',
       'templates.cjs',
+      'spinner.cjs',
     ];
 
     for (const mod of expectedModules) {

--- a/test/spinner.test.cjs
+++ b/test/spinner.test.cjs
@@ -1,0 +1,193 @@
+'use strict';
+
+/**
+ * test/spinner.test.cjs — Unit tests for lib/spinner.cjs
+ *
+ * Tests run in non-TTY mode (piped stdout), so SUPPORTS_SPINNER is false
+ * and all output falls back to plain log lines. This makes assertions
+ * on stdout straightforward without ANSI escape sequences.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createSpinner, withSpinner, SUPPORTS_SPINNER } = require('../lib/spinner.cjs');
+
+describe('spinner module exports', () => {
+  it('exports createSpinner as a function', () => {
+    assert.strictEqual(typeof createSpinner, 'function');
+  });
+
+  it('exports withSpinner as a function', () => {
+    assert.strictEqual(typeof withSpinner, 'function');
+  });
+
+  it('exports SUPPORTS_SPINNER as a boolean', () => {
+    assert.strictEqual(typeof SUPPORTS_SPINNER, 'boolean');
+  });
+
+  it('SUPPORTS_SPINNER is false in non-TTY test environment', () => {
+    // Tests run with piped stdout so process.stdout.isTTY is undefined/false
+    assert.strictEqual(SUPPORTS_SPINNER, false);
+  });
+});
+
+describe('createSpinner', () => {
+  let captured;
+  let originalWrite;
+
+  beforeEach(() => {
+    captured = '';
+    originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it('returns an object with start, succeed, fail, stop methods', () => {
+    const s = createSpinner('test-stage');
+    assert.strictEqual(typeof s.start, 'function');
+    assert.strictEqual(typeof s.succeed, 'function');
+    assert.strictEqual(typeof s.fail, 'function');
+    assert.strictEqual(typeof s.stop, 'function');
+  });
+
+  it('start() emits stage name in non-TTY mode', () => {
+    const s = createSpinner('validate');
+    s.start();
+    s.stop();
+    assert.ok(captured.includes('validate'), `Expected "validate" in output, got: ${captured}`);
+  });
+
+  it('succeed() emits success line with default stage label', () => {
+    const s = createSpinner('create-worktree');
+    s.start();
+    s.succeed();
+    assert.ok(
+      captured.includes('create-worktree'),
+      `Expected "create-worktree" in success output, got: ${captured}`
+    );
+  });
+
+  it('succeed() emits custom message when provided', () => {
+    const s = createSpinner('execute-gsd');
+    s.start();
+    s.succeed('GSD executed successfully');
+    assert.ok(
+      captured.includes('GSD executed successfully'),
+      `Expected custom message in output, got: ${captured}`
+    );
+  });
+
+  it('fail() emits failure line with default stage label', () => {
+    const s = createSpinner('create-pr');
+    s.start();
+    s.fail();
+    assert.ok(
+      captured.includes('create-pr'),
+      `Expected "create-pr" in fail output, got: ${captured}`
+    );
+  });
+
+  it('fail() emits custom message when provided', () => {
+    const s = createSpinner('triage');
+    s.start();
+    s.fail('triage failed: issue not found');
+    assert.ok(
+      captured.includes('triage failed: issue not found'),
+      `Expected custom fail message in output, got: ${captured}`
+    );
+  });
+
+  it('start() accepts an optional label override', () => {
+    const s = createSpinner('initial-label');
+    s.start('overridden-label');
+    s.stop();
+    assert.ok(
+      captured.includes('overridden-label'),
+      `Expected overridden label in output, got: ${captured}`
+    );
+  });
+
+  it('stop() does not emit any output in non-TTY mode (no clearLine side effects)', () => {
+    const s = createSpinner('silent-stop');
+    // In non-TTY mode, start() emits a line but stop() does nothing extra
+    captured = ''; // Reset after start
+    s.stop();
+    // stop() alone emits nothing
+    assert.strictEqual(captured, '');
+  });
+});
+
+describe('withSpinner', () => {
+  let captured;
+  let originalWrite;
+
+  beforeEach(() => {
+    captured = '';
+    originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it('resolves with the return value of the wrapped function', async () => {
+    const result = await withSpinner('stage', async () => 42);
+    assert.strictEqual(result, 42);
+  });
+
+  it('emits success output when fn resolves', async () => {
+    await withSpinner('pipeline', async () => 'done');
+    assert.ok(
+      captured.includes('pipeline'),
+      `Expected "pipeline" in success output, got: ${captured}`
+    );
+  });
+
+  it('uses custom successMessage when provided', async () => {
+    await withSpinner('validate', async () => {}, { successMessage: 'validation passed' });
+    assert.ok(
+      captured.includes('validation passed'),
+      `Expected custom success message in output, got: ${captured}`
+    );
+  });
+
+  it('emits fail output and rethrows when fn rejects', async () => {
+    const boom = new Error('test failure');
+    let thrown;
+    try {
+      await withSpinner('create-pr', async () => { throw boom; });
+    } catch (err) {
+      thrown = err;
+    }
+    assert.strictEqual(thrown, boom, 'Should rethrow the original error');
+    assert.ok(
+      captured.includes('fail') || captured.includes('create-pr'),
+      `Expected failure output, got: ${captured}`
+    );
+  });
+
+  it('uses custom failMessage when fn rejects', async () => {
+    try {
+      await withSpinner('execute-gsd', async () => { throw new Error('x'); }, {
+        failMessage: 'gsd execution failed'
+      });
+    } catch {
+      // expected
+    }
+    assert.ok(
+      captured.includes('gsd execution failed'),
+      `Expected custom fail message in output, got: ${captured}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lib/spinner.cjs` — a zero-dependency spinner utility with `createSpinner` and `withSpinner` helpers that cycle `|/-\` frames with elapsed time in TTY mode, falling back to plain log lines in non-TTY/CI environments
- Integrates spinners into `bin/mgw.cjs` so `mgw run` displays a named pipeline stage overview before handing off to claude, and a live spinner in `--quiet` mode that shows succeed/fail on completion
- Exports `createSpinner`, `withSpinner`, and `SUPPORTS_SPINNER` from `lib/index.cjs` barrel for use by any future pipeline step
- Adds 17 unit tests in `test/spinner.test.cjs` covering all spinner methods, non-TTY fallback behavior, and `withSpinner` error propagation

Closes #120

## Milestone Context

- **Milestone:** v4 — Interactive CLI & TUI
- **Phase:** 28 — Pipeline Progress Indicators and Live Status
- **Issue:** 4 of 9 in milestone

## Changes

**lib/spinner.cjs** (new)
- `createSpinner(stage)` — returns `{ start, succeed, fail, stop }` object; animates at 100ms in TTY, plain lines in non-TTY
- `withSpinner(stage, fn, opts)` — wraps async fn with spinner lifecycle; rethrows on reject
- `SUPPORTS_SPINNER` — boolean export for TTY+non-CI detection

**lib/index.cjs**
- Added `require('./spinner.cjs')` to barrel export

**bin/mgw.cjs**
- Added `STAGE_LABELS` map for human-readable stage names per command
- Added `RUN_PIPELINE_STAGES` array for pipeline stage banner
- Updated `runAiCommand()` — shows spinner in `--quiet` mode wrapping the full claude invocation; shows brief stage indicator in streaming mode
- Updated `run` command action — prints pipeline stage overview (`validate → triage → create-worktree → execute-gsd → create-pr`) before invoking claude

**test/mgw.test.cjs**
- Added `spinner.cjs` to the lib modules existence check

**test/spinner.test.cjs** (new)
- 17 tests covering module exports, createSpinner methods, and withSpinner success/fail/rethrow paths

## Test Plan

- [x] All 127 tests pass (`npm test` — 110 existing + 17 new spinner tests)
- [x] `createSpinner` start/succeed/fail/stop methods verified in non-TTY test environment
- [x] `withSpinner` resolves return values, emits success output, rethrows on reject
- [x] `SUPPORTS_SPINNER` is correctly `false` in piped/non-TTY contexts
- [x] `lib/index.cjs` barrel exports `createSpinner`, `withSpinner`, `SUPPORTS_SPINNER`
- [ ] Manual: run `mgw run <number> --quiet` and verify spinner appears with elapsed time
- [ ] Manual: run `mgw run <number>` (streaming) and verify stage banner prints before claude output