### PR TITLE
feat(init): add shell completion installation step to mgw:init

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -214,11 +214,13 @@ gh label create "mgw:blocked" --description "Pipeline blocked by stakeholder com
 </step>
 
 <step name="install_completions">
+<!-- MERGE NOTE: PR #125 (config wizard) also modifies commands/init.md.
+     Resolve conflict when merging — include both install_completions and run_config_wizard steps. -->
 **Offer to install shell completions (opt-in):**
 
 Locate the completions directory bundled with the MGW package:
 ```bash
-MGW_PKG_DIR=$(node -e "require.resolve('mgw/package.json')" 2>/dev/null | xargs dirname 2>/dev/null || echo "")
+MGW_PKG_DIR=$(node -e "const path = require('path'); console.log(path.resolve(__dirname, '..', '..'))" 2>/dev/null || echo "")
 COMPLETIONS_DIR="${MGW_PKG_DIR}/completions"
 ```
 
@@ -252,8 +254,13 @@ cp "${COMPLETIONS_DIR}/mgw.${SHELL_EXT}" "${COMPLETION_TARGET_DIR}/mgw.${SHELL_E
 Then show the source/activation line appropriate for the shell:
 - bash: `# Reload with: source ~/.local/share/bash-completion/completions/mgw.bash`
   (or add to ~/.bashrc: `source ~/.local/share/bash-completion/completions/mgw.bash`)
-- zsh: `# Reload with: fpath=(~/.zsh/completions $fpath) && autoload -U compinit && compinit`
-  (or add to ~/.zshrc if not already present)
+- zsh: Add to ~/.zshrc (required — ~/.zsh/completions is not in default $fpath):
+  ```
+  fpath=(~/.zsh/completions $fpath)
+  autoload -Uz compinit
+  compinit
+  ```
+  Then reload: `source ~/.zshrc`
 - fish: `# Completions loaded automatically from ~/.config/fish/completions/`
 
 If user answers no → skip, note "Shell completions: skipped" in report.


### PR DESCRIPTION
## Summary
- Adds `install_completions` step to `mgw:init` that detects the user's current shell (bash/zsh/fish) and offers to copy the appropriate completion script from the bundled `completions/` directory
- Step is opt-in by default in interactive mode (prompts `[Y/n]`) and skips gracefully in non-interactive/CI contexts, printing a manual install hint instead
- Completion install is idempotent — safe to re-run; overwrites existing file at target
- Init report updated with a `Shell completions` status line showing `installed (bash|zsh|fish)`, `skipped`, or `not available`

Closes #124

## Milestone Context
- **Milestone:** v4 — Interactive CLI & TUI
- **Phase:** 29 — Shell Completions and Config Wizard
- **Issue:** 8 of 9 in milestone

## Changes
**commands/init.md**
- Updated `description` frontmatter to reflect completion install capability
- Added `install_completions` step (between `ensure_labels` and `report`) covering: package dir resolution, shell detection, per-shell target path mapping, interactive prompt with default-yes, non-interactive fallback hint, and activation instructions
- Updated `report` step to include `Shell completions` status line
- Added three new `success_criteria` entries for the completion install behaviour

## Test Plan
- [ ] Run `mgw:init` in a new repo with mgw installed globally — verify prompt appears for detected shell
- [ ] Answer `n` — verify report shows `Shell completions: skipped`
- [ ] Answer `y` (or Enter) — verify file copied to correct target dir and activation hint printed
- [ ] Run again — verify idempotent (no error, overwrites existing)
- [ ] Run in non-interactive context (e.g. `mgw:init < /dev/null`) — verify prompt is skipped and manual install hint is shown
- [ ] Run without mgw globally installed — verify step is skipped silently and report shows `not available`