### PR TITLE
feat(init): add interactive config wizard for first-time setup

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -215,6 +215,8 @@ gh label create "mgw:blocked" --description "Pipeline blocked by stakeholder com
 </step>
 
 <step name="run_config_wizard">
+<!-- MERGE NOTE: PR #124 (completion install) also modifies commands/init.md.
+     Resolve conflict when merging — include both run_config_wizard and install_completions steps. -->
 **Run interactive config wizard for first-time setup (skip if --no-config or config already exists):**
 
 Check whether the wizard should run:

--- a/lib/config-wizard.cjs
+++ b/lib/config-wizard.cjs
@@ -78,6 +78,9 @@ async function promptChoice(rl, question, choices, defaultValue) {
  * @returns {Promise<object>} The config object that was written
  */
 async function runWizard(mgwDir) {
+  if (!process.stdin.isTTY) {
+    throw new Error('runWizard: stdin is not a TTY — cannot prompt interactively');
+  }
   const configPath = path.join(mgwDir, 'config.json');
 
   const detectedUsername = detectGitHubUsername();
@@ -91,7 +94,7 @@ async function runWizard(mgwDir) {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
-    terminal: true,
+    terminal: process.stdout.isTTY,
   });
 
   try {
@@ -163,6 +166,7 @@ async function runWizard(mgwDir) {
  *
  * Returns false (skip) when:
  *   - --no-config flag is present in argv
+ *   - process.stdin is not a TTY (e.g. piped/automated execution)
  *   - .mgw/config.json already exists
  *
  * @param {string} mgwDir - Absolute path to the .mgw/ directory
@@ -171,13 +175,10 @@ async function runWizard(mgwDir) {
  */
 function shouldRunWizard(mgwDir, argv) {
   const args = argv || process.argv;
-  if (args.includes('--no-config')) {
-    return false;
-  }
+  if (args.includes('--no-config')) return false;
+  if (!process.stdin.isTTY) return false;
   const configPath = path.join(mgwDir, 'config.json');
-  if (fs.existsSync(configPath)) {
-    return false;
-  }
+  if (fs.existsSync(configPath)) return false;
   return true;
 }
 

--- a/test/config-wizard.test.cjs
+++ b/test/config-wizard.test.cjs
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * test/config-wizard.test.cjs — Unit tests for lib/config-wizard.cjs
+ *
+ * Coverage:
+ *   shouldRunWizard  — all early-exit conditions
+ *   detectGitHubUsername — failure path (gh unavailable)
+ *
+ * Note on runWizard: the function requires an interactive TTY to operate
+ * (it opens a readline interface and awaits user input). Full end-to-end
+ * tests are not practical without a PTY harness. The isTTY guard path is
+ * covered indirectly via shouldRunWizard tests, and the guard itself is a
+ * trivial throw — integration smoke-testing in a real terminal is sufficient.
+ *
+ * Mocking strategy for process.stdin.isTTY:
+ *   process.stdin.isTTY is a writable property in test environments.
+ *   We save the original value, override it, then restore after each test.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const WIZARD_MODULE = path.resolve(__dirname, '..', 'lib', 'config-wizard.cjs');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reload lib/config-wizard.cjs fresh (evicts module cache).
+ */
+function loadWizard() {
+  delete require.cache[WIZARD_MODULE];
+  return require(WIZARD_MODULE);
+}
+
+/**
+ * Create a temporary directory and return its path.
+ */
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mgw-wizard-test-'));
+}
+
+/**
+ * Override process.stdin.isTTY for the duration of a test.
+ * Returns a restore function.
+ * @param {boolean|undefined} value
+ */
+function overrideStdinTTY(value) {
+  const original = process.stdin.isTTY;
+  process.stdin.isTTY = value;
+  return () => { process.stdin.isTTY = original; };
+}
+
+// ---------------------------------------------------------------------------
+// shouldRunWizard
+// ---------------------------------------------------------------------------
+
+describe('shouldRunWizard', () => {
+  let tmpDir;
+  let restoreTTY;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    // Default: behave as TTY so only one guard triggers at a time
+    restoreTTY = overrideStdinTTY(true);
+  });
+
+  afterEach(() => {
+    restoreTTY();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete require.cache[WIZARD_MODULE];
+  });
+
+  it('returns false when --no-config is in argv', () => {
+    const { shouldRunWizard } = loadWizard();
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw', '--no-config']);
+    assert.equal(result, false);
+  });
+
+  it('returns false when config.json already exists in mgwDir', () => {
+    const { shouldRunWizard } = loadWizard();
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), '{}', 'utf-8');
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw']);
+    assert.equal(result, false);
+  });
+
+  it('returns false when process.stdin.isTTY is falsy (piped/automated)', () => {
+    restoreTTY();
+    restoreTTY = overrideStdinTTY(false);
+    const { shouldRunWizard } = loadWizard();
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw']);
+    assert.equal(result, false);
+  });
+
+  it('returns false when process.stdin.isTTY is undefined', () => {
+    restoreTTY();
+    restoreTTY = overrideStdinTTY(undefined);
+    const { shouldRunWizard } = loadWizard();
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw']);
+    assert.equal(result, false);
+  });
+
+  it('returns true when no flag, no config.json, and stdin is a TTY', () => {
+    // restoreTTY already set isTTY to true in beforeEach
+    const { shouldRunWizard } = loadWizard();
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw']);
+    assert.equal(result, true);
+  });
+
+  it('--no-config takes priority over TTY check (isTTY=true but flag present)', () => {
+    const { shouldRunWizard } = loadWizard();
+    const result = shouldRunWizard(tmpDir, ['node', 'mgw', '--no-config']);
+    assert.equal(result, false);
+  });
+
+  it('uses process.argv when argv argument is omitted', () => {
+    // Inject --no-config into process.argv temporarily
+    const original = process.argv;
+    process.argv = ['node', 'mgw', '--no-config'];
+    try {
+      const { shouldRunWizard } = loadWizard();
+      assert.equal(shouldRunWizard(tmpDir), false);
+    } finally {
+      process.argv = original;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectGitHubUsername
+// ---------------------------------------------------------------------------
+
+describe('detectGitHubUsername', () => {
+  afterEach(() => {
+    delete require.cache[WIZARD_MODULE];
+  });
+
+  it('returns null when the gh command fails (gh not available / not authenticated)', () => {
+    // We cannot mock execSync without a full module-replacement framework,
+    // but we CAN test the failure path by temporarily manipulating PATH so
+    // that `gh` resolves to a command that exits non-zero (or doesn't exist).
+    // Using a sub-shell one-liner is the simplest portable approach.
+    const originalPath = process.env.PATH;
+    process.env.PATH = '/dev/null'; // nothing on PATH — execSync will throw ENOENT
+
+    try {
+      const { detectGitHubUsername } = loadWizard();
+      const result = detectGitHubUsername();
+      assert.equal(result, null);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/config-wizard.cjs` with `runWizard()` and `shouldRunWizard()` — the complete wizard implementation using Node.js `readline`
- The wizard prompts for GitHub username (auto-detected via `gh api user`), default issue state filter, default issue limit, and default assignee filter, then writes `.mgw/config.json`
- Updates `commands/init.md` with a new `run_config_wizard` step inserted after the GitHub setup and before the completion report
- Wizard is skippable via `--no-config` flag or automatically bypassed when `.mgw/config.json` already exists

Closes #125

## Milestone Context
- **Milestone:** v4 — Interactive CLI & TUI
- **Phase:** 29 — Shell Completions and Config Wizard
- **Issue:** 9 of 9 in milestone

## Changes
- **`lib/config-wizard.cjs`** (new) — wizard logic: `shouldRunWizard()` checks for `--no-config` flag and pre-existing config; `runWizard()` drives the interactive prompt session and writes `.mgw/config.json`; `detectGitHubUsername()` auto-detects via `gh api user`
- **`commands/init.md`** — added `run_config_wizard` step with full pseudocode; updated `argument-hint`, objective description, report layout, and success criteria to reflect config.json output

## Test Plan
- [ ] Run `mgw:init` in a fresh repo with no `.mgw/config.json` — wizard should prompt all four questions and write `.mgw/config.json`
- [ ] Run `mgw:init --no-config` — wizard should be skipped entirely, report shows `skipped`
- [ ] Run `mgw:init` when `.mgw/config.json` already exists — wizard should be skipped, report shows `exists`
- [ ] Verify `shouldRunWizard()` returns `false` when `--no-config` is in argv
- [ ] Verify `shouldRunWizard()` returns `false` when config file exists
- [ ] Verify `detectGitHubUsername()` returns null gracefully when `gh` is not authenticated
- [ ] Verify pressing Enter on each prompt accepts the displayed default value